### PR TITLE
Change hash type to xxh64

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,16 +3,15 @@
 Work in progress, but it's usable.
 
 To install, enable Texture Replacement in PPSSPP dev menu and put downloaded files to:
+`PPSSPP/memstick/PSP/TEXTURES/%GAME_ID%`
 
-PPSSPP\memstick\PSP\TEXTURES\\%GAME_ID%
-
-Game IDs:
-
-EU - UCES01421
-
-NA - UCUS98751
-
-JP - NPJG00122
+|  Region | Game ID     |
+| ------: | ----------- |
+|      EU | `UCES01421` |
+|      NA | `UCUS98751` |
+|      JP | `NPJG00122` |
+|      CN | `UCAS40318` |
+| DxD mod | `INFN00001` |
 
 # Special thanks to:
 

--- a/textures.ini
+++ b/textures.ini
@@ -3,14 +3,16 @@
 
 [options]
 version = 1
-hash = quick
+hash = xxh64
+ignoreAddress = True
+reduceHash = True
 
 [hashes]
 
-00000000dc4184ef97d9140c=team.png
-000000005430f0779473fa04=rarepons.png
-00000000c2332777130f0985=ui/game_ui.png
-0000000054a491b9c0a4100f=ui/barracks_menu.png
+00000000dc4184efcef04eb6=team.png
+000000005430f07763b21ad8=rarepons.png
+00000000c2332777af4ab260=ui/game_ui.png
+0000000054a491b91a9cd7d7=ui/barracks_menu.png
 
 #==============Customizables==============#
 
@@ -18,779 +20,777 @@ hash = quick
 # Visible
 
 	# English
-	000000005b991ae6fa80f8aa = ui/bottomtext.png
-	000000005b991ae61bae40f7 = ui/bottomtext.png
+	# HASH_TO_UPDATE_000000005b991ae6fa80f8aa = ui/bottomtext.png
+	000000005b991ae64ee4c998 = ui/bottomtext.png
 	# Polish
-	000000009154261cecfbfd34 = ui/polish/bottomtext_pl.png
+	000000009154261c9f2fdf99 = ui/polish/bottomtext_pl.png
 	
 # Not visible
-	# 000000005b991ae61bae40f7 = ui/bottomtextclear.png
-	# 000000005b991ae61bae40f7 = ui/bottomtextclear.png
+	# 000000005b991ae64ee4c998 = ui/bottomtextclear.png
+	# 000000005b991ae64ee4c998 = ui/bottomtextclear.png
 	
 # Choose if you want to see damage numbers
 # Visible
-	00000000d297a168af8159e8 = effects/effects.png
+	00000000d297a1688f1af204 = effects/effects.png
 # Not visible
-	#00000000d297a168af8159e8 = effects/effects_no_nr.png
+	#00000000d297a1688f1af204 = effects/effects_no_nr.png
 	
 # Choose your favorite Meden
-	000000004a130c0e77aef365 = patapons/meden.png
-	#000000004a130c0e77aef365 = patapons/blue_meden.png
+	000000004a130c0e3ecb1748 = patapons/meden.png
+	#000000004a130c0e3ecb1748 = patapons/blue_meden.png
 
 #==============General UI==============#
 		
-	0000000051c46a7dd7c5cc38 = ui/font.png
+	0000000051c46a7d7695144b = ui/font.png
 	
 	# Eula
-	09205b80d439d72900000000 = ui/eula.png
-	09215cc0d439d72900000000 = ui/eula_1.png
-	09225e00d439d72900000000 = ui/eula_2.png
-	09235f40d439d72900000000 = ui/eula_3.png
-	09246080d439d72900000000 = ui/eula_4.png
+	00000000d439d729b4dd38e9 = ui/eula.png
+	00000000d439d729f32dbed5 = ui/eula_1.png
+	00000000d439d72979d071e6 = ui/eula_2.png
+	00000000d439d729cca25723 = ui/eula_3.png
+	00000000d439d729ba3a1120 = ui/eula_4.png
 
 	# Title Screen
-	00000000f679ff12b962dcdb = ui/title_screen_english.png
-	000000003ea6e158b4eb0326 = ui/title_screen_2.png
-	0000000082ada8b23e52f2d2 = ui/title_screen_3.png
+	00000000f679ff12fad95310 = ui/title_screen_english.png
+	000000003ea6e158faf372f8 = ui/title_screen_2.png
+	0000000082ada8b26aae18e8 = ui/title_screen_3.png
 
 	# Intro
-	0000000073315afd24f11ac5 = ui/intro_hoshipon.png
-	00000000a5899ba2d3be6955 = ui/intro_yarida.png
-	0000000037cf1ecf1154a1d9 = ui/intro_taterazay.png
-	000000002ff3fd0cae889d20 = ui/intro_yumiyacha.png
-	0000000060abd2b6e84e29b2 = ui/intro_glow.png
-	0000000084366563dca0c23b = ui/intro_glow_1.png
+	0000000073315afdca36dc10 = ui/intro_hoshipon.png
+	00000000a5899ba2f45b7d4a = ui/intro_yarida.png
+	0000000037cf1ecff05fd5c1 = ui/intro_taterazay.png
+	000000002ff3fd0c06512f7e = ui/intro_yumiyacha.png
+	0000000060abd2b68e9dedb7 = ui/intro_glow.png
+	000000008436656350192214 = ui/intro_glow_1.png
 		
 	# Main menu
-	000000004c2c77fa161485fb = ui/language_select.png
-	00000000f5b425951f313529 = ui/menu_font.png
-	00000000bf408682e34cb034 = ui/options.png
-	0000000070aee345191a4986 = ui/loadingicon.png
-	00000000d5508784a9d9e26a = ui/loading_patapons.png
+	000000004c2c77fab4d18d2a = ui/language_select.png
+	00000000f5b425950a02ff09 = ui/menu_font.png
+	00000000bf4086827953ff2b = ui/options.png
+	0000000070aee345f46e82ba = ui/loadingicon.png
+	00000000d5508784a4ae8445 = ui/loading_patapons.png
 	
 	# In-Game UI
-	0000000026f1aec9e920c4a5 = ui/bottomtips.png	
-	00000000202afc9300000000 = ui/game_ui.png
+	0000000026f1aec9090a2a14 = ui/bottomtips.png	
+	# HASH_TO_UPDATE_00000000202afc9300000000 = ui/game_ui.png
 	
-	000000009154261cecfbfd34 = ui/polish/bottomtext_pl.png
-	0000000037d928fc5279553d = ui/polish/bottomtips_pl.png
-	00000000988fad265bcd247d = ui/polish/game_ui_pl.png
+	000000009154261c9f2fdf99 = ui/polish/bottomtext_pl.png
+	0000000037d928fc07cabdce = ui/polish/bottomtips_pl.png
+	00000000988fad26a03c0834 = ui/polish/game_ui_pl.png
 	
 	# Hideout
-	00000000b4d331051f8e26c9 = ui/medenshop.png
-	0000000076a8be2c884bc6ec = ui/arrows.png
-	00000000c0c911384ea8c74a = ui/arrows1.png
-	000000002a7800e591d007ea = ui/speechbox.png
-	00000000fd63fc4224b29508 = ui/item_loading.png
-	000000002cbeb147d6c7de34 = ui/barracks_menu.png
-	000000005430f0779473fa04 = ui/rarepons_menu.png											
-	00000000075a6cb33a03befa = ui/headquarters_menu.png
-	000000004ba93c4c13b2815a = ui/headquarters_menu_1.png
-	0000000055752a127338f4d7 = ui/countdown.png
-	000000004ef455946c3de180 = ui/corner.png
-	00000000adfd435fd76d4bfc = ui/buttonsandarrows.png
-	00000000ccfd80424f9cb328 = ui/tips_arrows.png
-	000000006376b61041e1d735 = ui/depart.png
+	00000000b4d33105e730c7a9 = ui/medenshop.png
+	0000000076a8be2cd452a45e = ui/arrows.png
+	00000000c0c91138d2a5b80c = ui/arrows1.png
+	000000002a7800e5a08875c0 = ui/speechbox.png
+	# HASH_TO_UPDATE_00000000fd63fc4224b29508 = ui/item_loading.png
+	000000002cbeb1476a294bed = ui/barracks_menu.png
+	000000005430f07763b21ad8 = ui/rarepons_menu.png
+	00000000075a6cb3c3752f8a = ui/headquarters_menu.png
+	000000004ba93c4c1a26e1df = ui/headquarters_menu_1.png
+	0000000055752a124d399136 = ui/countdown.png
+	000000004ef45594f4e4d797 = ui/corner.png
+	00000000adfd435f833da522 = ui/buttonsandarrows.png
+	00000000ccfd8042bef8a72a = ui/tips_arrows.png
+	000000006376b610f1836a5c = ui/depart.png
 
 	# Tips
-	09d943c0bcd9364b00000000 = ui/tips/tip.png
-	09d943c096ea1ac900000000 = ui/tips/tip_1.png
-	09d943c0616fbfd900000000 = ui/tips/tip_2.png
-	09d943c0961fb6d800000000 = ui/tips/tip_3.png
-	09d943c0467bddff00000000 = ui/tips/tip_4.png
-	09d943c0bc59430500000000 = ui/tips/tip_5.png
-	09d943c0249e173100000000 = ui/tips/tip_6.png
-	09d943c083a7b3f500000000 = ui/tips/tip_7.png
-	09d943c092aec4a500000000 = ui/tips/tip_8.png
-	09d943c0ece4fff200000000 = ui/tips/tip_9.png
-	09d943c0f6be4b0200000000 = ui/tips/tip_10.png
-	09d943c0d264078d00000000 = ui/tips/tip_11.png
-	09d943c0ea7e5c0100000000 = ui/tips/tip_12.png
-	09d943c0064c83aa00000000 = ui/tips/tip_13.png
-	09d943c03078badb00000000 = ui/tips/tip_14.png
-	09d943c0ea52120200000000 = ui/tips/tip_15.png
-	09d943c055ee467600000000 = ui/tips/tip_16.png
-	09d943c0292b6cdf00000000 = ui/tips/tip_17.png
-	09d943c05b64a60800000000 = ui/tips/tip_18.png
-	09d943c0623ddcb000000000 = ui/tips/tip_19.png
-	09d943c0bb75848b00000000 = ui/tips/tip_20.png
-	09d943c0f0fcdd6000000000 = ui/tips/tip_21.png
-	09d943c0027bc5cc00000000 = ui/tips/tip_22.png
-	09d943c0883b257600000000 = ui/tips/tip_23.png
-	09d943c0b7b56c1b00000000 = ui/tips/tip_24.png
-	09d943c0dfb84ad800000000 = ui/tips/tip_25.png
-	09d943c0a9a1870800000000 = ui/tips/tip_26.png
-	09d943c0da8ed1f800000000 = ui/tips/tip_27.png
-	09d943c04778321f00000000 = ui/tips/tip_28.png
-	09d943c01567413200000000 = ui/tips/tip_29.png
-	09d943c040f00d0900000000 = ui/tips/tip_30.png
-	09d943c06794000e00000000 = ui/tips/tip_31.png
-	09d943c0e0fecf1100000000 = ui/tips/tip_32.png
-	09d943c056c968e900000000 = ui/tips/tip_33.png
-	09d943c04668fd3000000000 = ui/tips/tip_34.png
-	09d943c06f35b30b00000000 = ui/tips/tip_35.png
-	09d943c04478eb9700000000 = ui/tips/tip_36.png
-	09d943c0c6a445df00000000 = ui/tips/tip_37.png
-	09d943c097aec77900000000 = ui/tips/tip_38.png
-	09d943c0fa5823d600000000 = ui/tips/tip_39.png
-	09d943c02568842400000000 = ui/tips/tip_40.png
-	09d943c0a4a9c4ed00000000 = ui/tips/tip_41.png
-	09d943c0d3fb78fd00000000 = ui/tips/tip_42.png
-	09d943c0d16fad1900000000 = ui/tips/tip_43.png
-	09d943c069da716500000000 = ui/tips/tip_44.png
-	09d943c0f228711500000000 = ui/tips/tip_45.png
-	09d943c0fa47161400000000 = ui/tips/tip_46.png
-	09d943c0079a8b7f00000000 = ui/tips/tip_47.png
-	09d943c03050ed9d00000000 = ui/tips/tip_48.png
-	09d943c0a62d45d300000000 = ui/tips/tip_49.png
-	09d943c0c4e2646600000000 = ui/tips/tip_50.png
-	09d943c01be822d900000000 = ui/tips/tip_51.png
-	09d943c0178470d000000000 = ui/tips/tip_52.png
-	09d943c0ba8846ca00000000 = ui/tips/tip_53.png
-	09d943c09aa37b7000000000 = ui/tips/tip_54.png
-	09d943c00e5ff6aa00000000 = ui/tips/tip_55.png
-	09d943c05bfc271d00000000 = ui/tips/tip_56.png
-	09d943c0ba6c1d7800000000 = ui/tips/tip_57.png
-	09d943c09cd06ac500000000 = ui/tips/tip_58.png
-	09d943c00cc5546800000000 = ui/tips/tip_59.png
-	09d943c0d7016ba100000000 = ui/tips/tip_60.png
-	09d943c02645f85d00000000 = ui/tips/tip_61.png
-	09d943c040192c4000000000 = ui/tips/tip_62.png
-	09d943c0bfd776f800000000 = ui/tips/tip_63.png
-	09d943c01ee9993700000000 = ui/tips/tip_64.png
-	09d943c0b0bc89a800000000 = ui/tips/tip_65.png
-	09d943c06ef0eb5500000000 = ui/tips/tip_66.png
-	09d943c0df33cd6100000000 = ui/tips/tip_67.png
-	09d943c0236ac21a00000000 = ui/tips/tip_68.png
-	09d943c01bc9aa5a00000000 = ui/tips/tip_69.png
-	09d943c05b1f0df600000000 = ui/tips/tip_70.png
-	09d943c00a172cc800000000 = ui/tips/tip_71.png
-	09d943c040feb8d100000000 = ui/tips/tip_72.png
-	09d943c01cab9ea000000000 = ui/tips/tip_73.png
-	09d943c0397ce78f00000000 = ui/tips/tip_74.png
-	09d943c0a29e724200000000 = ui/tips/tip_75.png
-	09d943c0cdf195a500000000 = ui/tips/tip_76.png
-	09d943c05fef044d00000000 = ui/tips/tip_77.png
-	09d943c0089eb80000000000 = ui/tips/tip_78.png
-	09d943c09664a52f00000000 = ui/tips/tip_79.png
-	09d943c070909d3700000000 = ui/tips/tip_80.png
-	09d943c0225902f300000000 = ui/tips/tip_81.png
-	09d943c0a5988de000000000 = ui/tips/tip_82.png
-	09d943c0f5561b0c00000000 = ui/tips/tip_83.png
-	09d943c0cc64fb9a00000000 = ui/tips/tip_84.png
-	09d943c06be8450100000000 = ui/tips/tip_85.png
-	09d943c07aafc43300000000 = ui/tips/tip_86.png
-	09d943c0ea67d70c00000000 = ui/tips/tip_87.png
-	09d943c0b600974900000000 = ui/tips/tip_88.png
-	09d943c0f1af652a00000000 = ui/tips/tip_89.png
-	09d943c0e104f6d900000000 = ui/tips/tip_90.png
-	09d943c0358f9e0b00000000 = ui/tips/tip_91.png
-	09d943c0300f5f4600000000 = ui/tips/tip_92.png
-	09d943c08ac06c4a00000000 = ui/tips/tip_93.png
-	09d943c0b2db8cac00000000 = ui/tips/tip_94.png
-	09d943c00959f4e400000000 = ui/tips/tip_95.png
-	09d943c0f5bc17ec00000000 = ui/tips/tip_96.png
-	09d943c0634c8c0500000000 = ui/tips/tip_97.png
-	09d943c0ff0a728700000000 = ui/tips/tip_98.png
-	09d943c05ac7e1ec00000000 = ui/tips/tip_99.png
-	09d943c00bf43a4200000000 = ui/tips/tip_100.png
-	09d921c0a4a9c4ed00000000 = ui/tips/tip_101.png
-	09d84d00ba6c1d7800000000 = ui/tips/tip_102.png
-	09d84f40292b6cdf00000000 = ui/tips/tip_103.png
-	09d85040d16fad1900000000 = ui/tips/tip_104.png
-	09d84940c6a445df00000000 = ui/tips/tip_105.png
-	09d83340f6be4b0200000000 = ui/tips/tip_106.png
-	09d921c0dfb84ad800000000 = ui/tips/tip_107.png
-	09d921c0bb75848b00000000 = ui/tips/tip_108.png
-	09d85bc0079a8b7f7b289f07 = ui/tips/tip_109.png
+	# 00000000bcd9364baae1f512 = ui/tips/tip.png
+	# 0000000096ea1ac9f5d42d4a = ui/tips/tip_1.png
+	# 00000000616fbfd925bba872 = ui/tips/tip_2.png
+	# 00000000961fb6d8db744327 = ui/tips/tip_3.png
+	# 00000000467bddff98f2359b = ui/tips/tip_4.png
+	# 00000000bc594305d25cca3e = ui/tips/tip_5.png
+	# 00000000249e173110165519 = ui/tips/tip_6.png
+	# 0000000083a7b3f5bc5ccb9a = ui/tips/tip_7.png
+	# 0000000092aec4a5f79248b3 = ui/tips/tip_8.png
+	# 00000000ece4fff20a46af11 = ui/tips/tip_9.png
+	# 00000000f6be4b028d7bb9bf = ui/tips/tip_10.png
+	# 00000000d264078dc3a4c038 = ui/tips/tip_11.png
+	# 00000000ea7e5c01ebf35df8 = ui/tips/tip_12.png
+	# 00000000064c83aa543fb716 = ui/tips/tip_13.png
+	# 000000003078badbbcb2bd49 = ui/tips/tip_14.png
+	# 00000000ea52120234f6bd41 = ui/tips/tip_15.png
+	# 0000000055ee46763b12515b = ui/tips/tip_16.png
+	# 00000000292b6cdf9adb0f69 = ui/tips/tip_17.png
+	# 000000005b64a6089f1922a8 = ui/tips/tip_18.png
+	# 00000000623ddcb02ba1fd48 = ui/tips/tip_19.png
+	# 00000000bb75848b1644114d = ui/tips/tip_20.png
+	# 00000000f0fcdd608ceba577 = ui/tips/tip_21.png
+	# 00000000027bc5cc79846e86 = ui/tips/tip_22.png
+	# 00000000883b2576aaeea022 = ui/tips/tip_23.png
+	# 00000000b7b56c1b3cf1cd44 = ui/tips/tip_24.png
+	# 00000000dfb84ad88a08d347 = ui/tips/tip_25.png
+	# 00000000a9a18708c558ceab = ui/tips/tip_26.png
+	# 00000000da8ed1f85206a563 = ui/tips/tip_27.png
+	# 000000004778321fe8ca9daf = ui/tips/tip_28.png
+	# 00000000156741327387e66a = ui/tips/tip_29.png
+	# 0000000040f00d092ac46cb0 = ui/tips/tip_30.png
+	# 000000006794000e6edc6629 = ui/tips/tip_31.png
+	# 00000000e0fecf1132619bfe = ui/tips/tip_32.png
+	# 0000000056c968e9e63e279f = ui/tips/tip_33.png
+	# 000000004668fd30c048b3f0 = ui/tips/tip_34.png
+	# 000000006f35b30b2f9ee3c6 = ui/tips/tip_35.png
+	# 000000004478eb975d0544bf = ui/tips/tip_36.png
+	# 00000000c6a445df730a94ba = ui/tips/tip_37.png
+	# 0000000097aec779f8512207 = ui/tips/tip_38.png
+	# 00000000fa5823d62e13b466 = ui/tips/tip_39.png
+	# 00000000256884248596b237 = ui/tips/tip_40.png
+	# 00000000a4a9c4ed2742964b = ui/tips/tip_41.png
+	# 00000000d3fb78fdfa81e30a = ui/tips/tip_42.png
+	# 00000000d16fad191ea60c89 = ui/tips/tip_43.png
+	# 0000000069da716506b7a8c2 = ui/tips/tip_44.png
+	# 00000000f2287115567645d2 = ui/tips/tip_45.png
+	# 00000000fa471614f08bcb9c = ui/tips/tip_46.png
+	# 00000000079a8b7f99fa8785 = ui/tips/tip_47.png
+	# 000000003050ed9d82049d5e = ui/tips/tip_48.png
+	# 00000000a62d45d3f4aa96f3 = ui/tips/tip_49.png
+	# 00000000c4e264661f8d1bc5 = ui/tips/tip_50.png
+	# 000000001be822d917a24921 = ui/tips/tip_51.png
+	# 00000000178470d0c2b50da0 = ui/tips/tip_52.png
+	# 00000000ba8846cae44f62e8 = ui/tips/tip_53.png
+	# 000000009aa37b70f8c34a5e = ui/tips/tip_54.png
+	# 000000000e5ff6aa7cdf0d6a = ui/tips/tip_55.png
+	# 000000005bfc271df070b85e = ui/tips/tip_56.png
+	# 00000000ba6c1d788c398ab6 = ui/tips/tip_57.png
+	# 000000009cd06ac5aaebf35a = ui/tips/tip_58.png
+	# 000000000cc55468e265a5c0 = ui/tips/tip_59.png
+	# 00000000d7016ba1ea6920f2 = ui/tips/tip_60.png
+	# 000000002645f85d8db4e9d2 = ui/tips/tip_61.png
+	# 0000000040192c40e3235a87 = ui/tips/tip_62.png
+	# 00000000bfd776f8aa0c7b8f = ui/tips/tip_63.png
+	# 000000001ee999374f4e9429 = ui/tips/tip_64.png
+	# 00000000b0bc89a88683d4bd = ui/tips/tip_65.png
+	# 000000006ef0eb551f3c7357 = ui/tips/tip_66.png
+	# 00000000df33cd61dfe8d065 = ui/tips/tip_67.png
+	# 00000000236ac21a9de97c6a = ui/tips/tip_68.png
+	# 000000001bc9aa5ac758071d = ui/tips/tip_69.png
+	# 000000005b1f0df66e5a0db2 = ui/tips/tip_70.png
+	# 000000000a172cc89ef35d35 = ui/tips/tip_71.png
+	# 0000000040feb8d1d246081a = ui/tips/tip_72.png
+	# 000000001cab9ea0f6c98521 = ui/tips/tip_73.png
+	# 00000000397ce78fd919e54b = ui/tips/tip_74.png
+	# 00000000a29e724266b620af = ui/tips/tip_75.png
+	# 00000000cdf195a57d9e5c74 = ui/tips/tip_76.png
+	# 000000005fef044dc55e47a3 = ui/tips/tip_77.png
+	# 00000000089eb8005e3ec496 = ui/tips/tip_78.png
+	# 000000009664a52faf3aece0 = ui/tips/tip_79.png
+	# 0000000070909d3736f6157c = ui/tips/tip_80.png
+	# 00000000225902f31556f51b = ui/tips/tip_81.png
+	# 00000000a5988de026e57215 = ui/tips/tip_82.png
+	# 00000000f5561b0c4e5f0970 = ui/tips/tip_83.png
+	# 00000000cc64fb9a9858bf88 = ui/tips/tip_84.png
+	# 000000006be845011b7c679d = ui/tips/tip_85.png
+	# 000000007aafc433cb3ee31b = ui/tips/tip_86.png
+	# 00000000ea67d70c4369eca4 = ui/tips/tip_87.png
+	# 00000000b6009749848b295d = ui/tips/tip_88.png
+	# 00000000f1af652a6e5f79e0 = ui/tips/tip_89.png
+	# 00000000e104f6d9157bb479 = ui/tips/tip_90.png
+	# 00000000358f9e0b332c1e24 = ui/tips/tip_91.png
+	# 00000000300f5f46bb25ae3d = ui/tips/tip_92.png
+	# 000000008ac06c4a2b6623d1 = ui/tips/tip_93.png
+	# 00000000b2db8cac280da1cf = ui/tips/tip_94.png
+	# 000000000959f4e49b54d454 = ui/tips/tip_95.png
+	# 00000000f5bc17ec26123d99 = ui/tips/tip_96.png
+	# 00000000634c8c0548ef9d76 = ui/tips/tip_97.png
+	# 00000000ff0a728778e79162 = ui/tips/tip_98.png
+	# 000000005ac7e1ecf8278899 = ui/tips/tip_99.png
+	# 000000000bf43a426fd10e3f = ui/tips/tip_100.png
+	# HASH_TO_UPDATE_09d921c0a4a9c4ed00000000 = ui/tips/tip_101.png
+	# HASH_TO_UPDATE_09d84d00ba6c1d7800000000 = ui/tips/tip_102.png
+	# HASH_TO_UPDATE_09d84f40292b6cdf00000000 = ui/tips/tip_103.png
+	# HASH_TO_UPDATE_09d85040d16fad1900000000 = ui/tips/tip_104.png
+	# HASH_TO_UPDATE_09d84940c6a445df00000000 = ui/tips/tip_105.png
+	# HASH_TO_UPDATE_09d83340f6be4b0200000000 = ui/tips/tip_106.png
+	# HASH_TO_UPDATE_09d921c0dfb84ad800000000 = ui/tips/tip_107.png
+	# HASH_TO_UPDATE_09d921c0bb75848b00000000 = ui/tips/tip_108.png
+	# HASH_TO_UPDATE_09d85bc0079a8b7f7b289f07 = ui/tips/tip_109.png
 	
 	# Sutra
-	000000000ee9f9b983d9d22d = ui/summongage.png
-	00000000099454a93401d35e = ui/summongagefull.png
-	0000000057ddae01b82f4e0f = ui/warning.png
-	00000000969a129aa688ca09 = ui/sutra.png
-	0000000024d8846ecb4dd687 = ui/sutra_ui.png
-	0000000055752a127338f4d7 = ui/countdown.png
+	000000000ee9f9b91156fdb9 = ui/summongage.png
+	# HASH_TO_UPDATE_00000000099454a93401d35e = ui/summongagefull.png
+	0000000057ddae0193afb7b4 = ui/warning.png
+	00000000969a129a7db254c1 = ui/sutra.png
+	0000000024d8846e223027f0 = ui/sutra_ui.png
+	0000000055752a124d399136 = ui/countdown.png
 	
 	# Drums
-	00000000926ff6d053ca96a7 = ui/drums/pata.png
-	00000000790fa5b56df8352e = ui/drums/pon.png
-	00000000871b192db4037219 = ui/drums/don.png
-	000000009427cb080dda478f = ui/drums/chaka.png
+	00000000926ff6d0d54d2415 = ui/drums/pata.png
+	00000000790fa5b59568b857 = ui/drums/pon.png
+	00000000871b192d7e73949f = ui/drums/don.png
+	000000009427cb08fa48ba64 = ui/drums/chaka.png
 
 	# Level End
-	00000000e9a50cbd5833d97e = ui/quest_complete.png
-	0000000011f0488691169dfe = ui/defeat.png
-	000000008e370d163f66e95c = ui/back_to_hideout.png
-	00000000521167ac9baa723e = ui/fight.png
-	00000000ab12ba273b0f2d1c = ui/defeat_mp.png
-	0000000003995c2ba8129807 = ui/end_stripes.png
+	00000000e9a50cbd21736500 = ui/quest_complete.png
+	0000000011f048863d99cece = ui/defeat.png
+	000000008e370d16ea913e5a = ui/back_to_hideout.png
+	00000000521167ac0d0e541c = ui/fight.png
+	00000000ab12ba27c612925a = ui/defeat_mp.png
+	0000000003995c2b0431f1ee = ui/end_stripes.png
 	
 	# Chests map
-	00000000457e4b071b7afda6 = ui/chest_menu_center.png
-	00000000b272213158c919a7 = ui/chest_menu_glow.png
-	00000000c9d05c30355aaea0 = ui/chest_menu_lighting.png
-	000000002c470dda4ced8f8e = ui/chest_menu_lighting_2.png
-	00000000366ac2b1e0cc788d = ui/chest_menu_border.png
-	00000000c9d05c30a34b1ee8 = ui/chest_menu_beam.png
-	00000000e4df62492cd59a04 = ui/chest_menu_shadow.png
-	000000002c8220e599ee0dd4 = ui/chest_menu_item_glow.png
-	0000000009aaf4c7488ee420 = ui/chest_menu_exit.png
+	00000000457e4b07d7146155 = ui/chest_menu_center.png
+	00000000b2722131ea00d798 = ui/chest_menu_glow.png
+	00000000c9d05c30bbaba5ef = ui/chest_menu_lighting.png
+	000000002c470dda34969413 = ui/chest_menu_lighting_2.png
+	00000000366ac2b1e1d2b016 = ui/chest_menu_border.png
+	00000000c9d05c30a4d0a3de = ui/chest_menu_beam.png
+	00000000e4df6249254a61dc = ui/chest_menu_shadow.png
+	000000002c8220e550a85b39 = ui/chest_menu_item_glow.png
+	0000000009aaf4c7850a21fa = ui/chest_menu_exit.png
 
 	
-	000000003810bb23534e901d = ui/status_effects.png
-	#00000000d2ee1c06d8af71f9 = ui/eq_menu.png
+	000000003810bb23252fe92d = ui/status_effects.png
+	#00000000d2ee1c0640c2fab3 = ui/eq_menu.png
 
 	# MP missions
-	000000003bc69c1e56981219 = ui/mp_host.png
-	00000000fabe0bcab14f9a6d = ui/circle.png
-	00000000b0c37ee4047d51aa = ui/cannon_icon.png
-	00000000e6d9af073400002e = ui/race_hud.png
-	00000000f5b425951f313529 = ui/menu_font.png
-	00000000db5bb4b7b709d874 = ui/mp_arrows.png
+	000000003bc69c1e6a2e39a1 = ui/mp_host.png
+	00000000fabe0bca8351b759 = ui/circle.png
+	00000000b0c37ee4be7a9824 = ui/cannon_icon.png
+	00000000e6d9af075bd30458 = ui/race_hud.png
+	00000000f5b425950a02ff09 = ui/menu_font.png
+	# HASH_TO_UPDATE_00000000db5bb4b7b709d874 = ui/mp_arrows.png
 	
 	# World map
-	0000000081c4cf2896b5642c = ui/world_map/map_selection.png
-	00000000ceb3f550af9fcedc = ui/world_map/map_selection2.png
-	000000009cca1856e146fb58 = ui/world_map/world_map_bg.png
-	00000000a583a83aefc647e3 = ui/world_map/world_map_bg1.png
-	00000000ff0331ddbcc29da9 = ui/world_map/map_ui.png
-	00000000d1294dea64241d43 = ui/world_map/map_arrows.png
-	00000000a9899af3c5112d4e = ui/world_map/mission_type.png
+	0000000081c4cf2802c5444d = ui/world_map/map_selection.png
+	00000000ceb3f550f7bf7e29 = ui/world_map/map_selection2.png
+	000000009cca1856f76f68dd = ui/world_map/world_map_bg.png
+	00000000a583a83aa1f37234 = ui/world_map/world_map_bg1.png
+	00000000ff0331dd0d0d3a34 = ui/world_map/map_ui.png
+	00000000d1294deaa7781211 = ui/world_map/map_arrows.png
+	00000000a9899af3d11ccc04 = ui/world_map/mission_type.png
 
 	# Skill menu
-	000000009171ca9e65f9b9d0 = ui/skill_icons.png
-	00000000f87449f354dec45b = ui/skill_menu.png
-	00000000d753675cd72e1947 = ui/skill_menu_ribbon.png
-	00000000be5e088939783263 = ui/skill_arrow.png
-	00000000f1a1c83144162741 = ui/skill_bg.png
-	000000007c49abbdbefa287a = ui/set_skill_rl.png
+	000000009171ca9e3356c224 = ui/skill_icons.png
+	00000000f87449f3627d7859 = ui/skill_menu.png
+	00000000d753675cf3fe9ee7 = ui/skill_menu_ribbon.png
+	00000000be5e088948c2612c = ui/skill_arrow.png
+	00000000f1a1c831ae0bcd49 = ui/skill_bg.png
+	000000007c49abbd58d8ca05 = ui/set_skill_rl.png
 
 	# Results screen
-	0000000003a72d9d2dbdaa8c = ui/results/results_scoreboard.png
-	00000000ec01b6714134f3ae = ui/results/results_stand.png			
+	0000000003a72d9d48080245 = ui/results/results_scoreboard.png
+	00000000ec01b671491f8c50 = ui/results/results_stand.png			
 	
 #==============Maps==============#
-	000000008614a51d9d8e2ef4 = maps/sign.png
-	0000000067d8be292cb5a8aa = maps/wall.png
-	00000000fb2c64d00ac886f0 = maps/wall_small.png
-	000000004840efbded9a82c1 = maps/level_totem.png
-	000000003389b8f5fd160feb = maps/cannon.png
-	00000000780e8f4c42f5b3d9 = maps/bone_hut.png
-	00000000bbfe930da5b37d45 = maps/bone_house.png
-	00000000064e0ca7e3ec7850 = maps/bone_flag.png
-	00000000390d1f4360f42712 = maps/mission_totem.png
+	000000008614a51d9c875094 = maps/sign.png
+	0000000067d8be295068dcc2 = maps/wall.png
+	00000000fb2c64d0cd42a374 = maps/wall_small.png
+	000000004840efbdcc133ee4 = maps/level_totem.png
+	000000003389b8f5e751e36f = maps/cannon.png
+	# HASH_TO_UPDATE_00000000780e8f4c42f5b3d9 = maps/bone_hut.png
+	00000000bbfe930ddc382ba9 = maps/bone_house.png
+	00000000064e0ca70c880e4b = maps/bone_flag.png
+	00000000390d1f43440dfb1a = maps/mission_totem.png
 	
 	# Grass and plants
-	0000000020b151398f7efb56 = maps/grass.png
-	0000000053f76e2b4c85d319 = maps/tallgrass.png
-	00000000f1023a04e6015c02 = maps/grass_rocks.png
-	00000000b40626d7ffd07ed7 = maps/heartgrass.png
-	00000000dee8157cf89c92e9 = maps/sunflower.png
+	0000000020b15139283b3a43 = maps/grass.png
+	0000000053f76e2b6eae7475 = maps/tallgrass.png
+	00000000f1023a0402827083 = maps/grass_rocks.png
+	00000000b40626d78356c527 = maps/heartgrass.png
+	# HASH_TO_UPDATE_00000000dee8157cf89c92e9 = maps/sunflower.png
 	
-	000000005cdd0ea1d8336516 = maps/stone_pile.png
-	00000000e70b70a062bf6933 = maps/rocks_bg.png
-	00000000aea6a65d4738d04c = maps/rocks.png
-	00000000e80ec6041bb29fb4 = maps/rocks1.png
-	0000000059b6fffb2ef73077 = maps/haze.png
-	0000000006f56d482afd2116 = maps/rocks_bg.png
-	00000000def476035310dcfb = maps/clouds_lightning_bg.png
-	00000000fa760f622f068c01 = maps/mountains_bg.png
-	000000004be14778ef8b3c7c = maps/trees_plain.png
-	000000000ad38c44cab662c3 = maps/trees_eye.png
-	0000000080a588e2ac2d229c = maps/trees_dead.png
-	00000000513505d6fe701ab0 = maps/plains.png
-	0000000032f7aff31ee57d1c = maps/plains1.png
-	00000000ec420932fb663fcd = maps/plains2.png
-	00000000fb087a09dc004889 = maps/plains3.png
-	#00000000f25c2f1c0d5496e1 = maps/clouds.png
-	0000000058d3e8bb32352e97 = maps/oasis.png
-	00000000d4be4994eedc0c31 = maps/desert.png
-	00000000830973b1ed03d8cb = maps/desert1.png
-	000000000acb9000778953ef = maps/birch_forest.png
-	00000000b8c928ce11e30b2e = maps/birch_forest_hills.png
-	00000000891070a4df84e117 = maps/birch_forest_hills1.png
-	#0000000001858b0a968a49f2 = maps/hills.png
-	00000000da76ca2bc691ad69 = maps/ruins.png
+	000000005cdd0ea17fb75c66 = maps/stone_pile.png
+	00000000e70b70a0d41f6c2e = maps/rocks_bg.png
+	00000000aea6a65d01ad079b = maps/rocks.png
+	00000000e80ec6041259c87b = maps/rocks1.png
+	0000000059b6fffbcf60e9a8 = maps/haze.png
+	0000000006f56d480d16b4c6 = maps/rocks_bg.png
+	00000000def476036a56cd9c = maps/clouds_lightning_bg.png
+	00000000fa760f62e3eae597 = maps/mountains_bg.png
+	000000004be14778a16c0fa5 = maps/trees_plain.png
+	000000000ad38c44d0773dde = maps/trees_eye.png
+	0000000080a588e2fb204e27 = maps/trees_dead.png
+	00000000513505d6edb3c040 = maps/plains.png
+	0000000032f7aff32ce04615 = maps/plains1.png
+	# HASH_TO_UPDATE_00000000ec420932fb663fcd = maps/plains2.png
+	00000000fb087a09e64846c0 = maps/plains3.png
+	#00000000f25c2f1c783db2f1 = maps/clouds.png
+	# HASH_TO_UPDATE_0000000058d3e8bb32352e97 = maps/oasis.png
+	00000000d4be4994e0bfdf22 = maps/desert.png
+	00000000830973b112fd765d = maps/desert1.png
+	# HASH_TO_UPDATE_000000000acb9000778953ef = maps/birch_forest.png
+	# HASH_TO_UPDATE_00000000b8c928ce11e30b2e = maps/birch_forest_hills.png
+	# HASH_TO_UPDATE_00000000891070a4df84e117 = maps/birch_forest_hills1.png
+	# HASH_TO_UPDATE_0000000001858b0a968a49f2 = maps/hills.png
+	# HASH_TO_UPDATE_00000000da76ca2bc691ad69 = maps/ruins.png
 	
-	00000000c12752b9b8413b4d = maps/mountains_stone.png
-	00000000a3a00b6cf41abde8 = maps/mountains_stone_1.png
-	0000000046edb3534e8c1b1d = maps/mountains_stone_2.png
-	00000000e85a2c1b3326fe4e = maps/range_floor.png
+	00000000c12752b97983da88 = maps/mountains_stone.png
+	00000000a3a00b6c4a0d8f03 = maps/mountains_stone_1.png
+	0000000046edb3534b764584 = maps/mountains_stone_2.png
+	00000000e85a2c1b377fe91a = maps/range_floor.png
 	
 	# Snow maps
-	00000000b43e2deea5264482 = maps/ice_tunnel.png
-	000000001251c43517bfdf2a = maps/ice_fields.png
-	00000000c90d5d5d223f32bd = maps/trees_snow.png
-	00000000810f1e54809c0db9 = maps/snow_shard_field.png
-	000000003bc247061c495514 = maps/plains_snow.png
-	000000007c0e5be73b432dfc = maps/plains_snow1.png
+	00000000b43e2dee76b0c5c0 = maps/ice_tunnel.png
+	# HASH_TO_UPDATE_000000001251c43517bfdf2a = maps/ice_fields.png
+	00000000c90d5d5d87906193 = maps/trees_snow.png
+	# HASH_TO_UPDATE_00000000810f1e54809c0db9 = maps/snow_shard_field.png
+	000000003bc247064f8e796e = maps/plains_snow.png
+	000000007c0e5be7d38df18b = maps/plains_snow1.png
 	
 	# Dungeon Cave
-	0000000009394286382ae87f = maps/cave.png
-	00000000d6a676e217d7e058 = maps/cave1.png
-	000000005c3adc50fa0fb7fa = maps/cave2.png
-	0000000063e6c7cdc8936d2b = maps/cave3.png
+	# HASH_TO_UPDATE_0000000009394286382ae87f = maps/cave.png
+	# HASH_TO_UPDATE_00000000d6a676e217d7e058 = maps/cave1.png
+	# HASH_TO_UPDATE_000000005c3adc50fa0fb7fa = maps/cave2.png
+	# HASH_TO_UPDATE_0000000063e6c7cdc8936d2b = maps/cave3.png
 	
 	# Dungeon Tower
-	000000004be11c499cb17b1b = maps/tower.png
-	000000002d8845ae37fbc139 = maps/tower1.png
-	00000000d4dda17a18f93735 = maps/tower2.png
+	000000004be11c498c95bb41 = maps/tower.png
+	000000002d8845ae4d8ccd52 = maps/tower1.png
+	00000000d4dda17a7428c582 = maps/tower2.png
 
 #==============Effects==============#
 
-	00000000b834f351a837d02c = effects/effects_1.png
-	000000000e27e8b4b0b1012a = effects/shield_block.png
-	00000000654f9786833e6ec4 = effects/glow.png
-	00000000da7d4de87b081f64 = effects/cannonball.png
-	00000000125ef13f42543f6a = effects/poison_bubble.png
-	0000000048997050442d56cc = effects/giant_spikeball.png
-	00000000e6847cc8f38dd597 = effects/idk.png
-	000000004e40ae748a0b769a = effects/gaeen_laser.png
-	000000008fb8d336a43cf72b = effects/chest_glow.png
-	00000000ef45cf50fbda0633 = effects/sandstorm.png
-	0000000050efd7a6a4450845 = effects/sandstorm1.png
-	0000000047cf2bc026e154a3 = effects/fire.png
-	0000000050426054882931cd = effects/fire_big.png
-	00000000ae5e2ba0ee626c54 = effects/star.png
-	0000000005cfbe3e7a47c9a4 = effects/yumi_trails.png
-	00000000a82803eb1d1dc702 = effects/item_pickup.png
-	000000007484ab6d639807d8 = effects/item_shine.png
-	000000006bd42a588ba56f77 = effects/snowflake.png
-	0000000058d1663aece97e14 = effects/projectile.png
-	00000000cbff84221121b2e6 = effects/chest_sparkle.png
-	00000000f8a96d3149af0541 = effects/buzz_bug.png
-	000000009b8d485f4cd94f70 = effects/rocket.png
-	000000007cbceee9a46f00a1 = effects/rocket_1.png
-	0000000050ce27d38e9540aa = effects/sleep_z.png
-	00000000a33d377822909d11 = effects/orb.png
-	000000007be665c9fee5168c = effects/arrow.png
+	00000000b834f35116628cb0 = effects/effects_1.png
+	000000000e27e8b47a9bc786 = effects/shield_block.png
+	00000000654f9786e3af84cb = effects/glow.png
+	00000000da7d4de8f2799cdc = effects/cannonball.png
+	00000000125ef13fb20d8274 = effects/poison_bubble.png
+	000000004899705088d36902 = effects/giant_spikeball.png
+	00000000e6847cc87161efb5 = effects/idk.png
+	# HASH_TO_UPDATE_000000004e40ae748a0b769a = effects/gaeen_laser.png
+	000000008fb8d33694fdd4ed = effects/chest_glow.png
+	00000000ef45cf50b58cc2b1 = effects/sandstorm.png
+	0000000050efd7a64833058d = effects/sandstorm1.png
+	0000000047cf2bc0bb6c8599 = effects/fire.png
+	000000005042605462395a90 = effects/fire_big.png
+	00000000ae5e2ba03b2cfcf4 = effects/star.png
+	0000000005cfbe3e558b98f4 = effects/yumi_trails.png
+	00000000a82803eba4ee592d = effects/item_pickup.png
+	# HASH_TO_UPDATE_000000007484ab6d639807d8 = effects/item_shine.png
+	000000006bd42a5865b99f8b = effects/snowflake.png
+	0000000058d1663ae15f07c8 = effects/projectile.png
+	00000000cbff8422b06310a4 = effects/chest_sparkle.png
+	00000000f8a96d3151a03810 = effects/buzz_bug.png
+	000000009b8d485f5a86ed40 = effects/rocket.png
+	# HASH_TO_UPDATE_000000007cbceee9a46f00a1 = effects/rocket_1.png
+	# HASH_TO_UPDATE_0000000050ce27d38e9540aa = effects/sleep_z.png
+	# HASH_TO_UPDATE_00000000a33d377822909d11 = effects/orb.png
+	000000007be665c9d3aac778 = effects/arrow.png
 	
 	# Sutras
-	00000000919038c900000000 = effects/sutra/yari_sutra_bg.png
-	000000008020e65c62f8e70a = effects/sutra/yari_rocks.png
+	00000000919038c9104dd9e3 = effects/sutra/yari_sutra_bg.png
+	000000008020e65c121d6317 = effects/sutra/yari_rocks.png
 	
 	# Taterazay effects
-	000000007ded5b9f555af608 = effects/taterazay_shield.png
+	000000007ded5b9f8c182220 = effects/taterazay_shield.png
 	
 	# Alosson effects
-	00000000fc07309c12ccdc95 = effects/tailwind.png
+	00000000fc07309c300eb51b = effects/tailwind.png
 	
 	# Tondenga effects
-	00000000a2aa59f590bcdaee = effects/tondenga_swirl.png
-	0000000039631c7e60279109 = effects/tondenga_smash.png
+	00000000a2aa59f5d24f888a = effects/tondenga_swirl.png
+	0000000039631c7e9c0f957b = effects/tondenga_smash.png
 	
 	# Charibasa effects
-	0000000084dfe13c264b40fc = effects/chari_wing.png
-	00000000c8105041284d49ad = effects/chari_halo.png
-	00000000e36efae030102296 = effects/chari_feather.png
-	00000000e8c53c03c8726ed9 = effects/chari_arrow.png
+	# HASH_TO_UPDATE_0000000084dfe13c264b40fc = effects/chari_wing.png
+	00000000c8105041532629b6 = effects/chari_halo.png
+	00000000e36efae03aa09af5 = effects/chari_feather.png
+	00000000e8c53c03ff9454fd = effects/chari_arrow.png
 	
 	# Pingrek effects
-	00000000098b1cca7fe69e76 = effects/ice.png
-	00000000be8a14c5ae08b7ca = effects/ice_wall.png
-	0000000054658d4eb0b561d7 = effects/ice_wall_sleep.png
-	00000000a88451fb6a70330f = effects/ice_dust.png
-	00000000f11fe5219ba2dd26 = effects/pingrek_heal.png
-	00000000e8329187d5b5160d = effects/pingrek_heal_1.png
-	000000002fdcf60320542ea1 = effects/pingrek_normalise.png
-	0000000014052d910ae3af1b = effects/pingrek_summon.png
-	000000006b9cc777f90af6d7 = effects/pingrek_magic.png
-	000000008c037cae9717c95f = effects/pingrek_magic_1.png
-	000000003cc93a45b87228a5 = effects/pingrek_attack.png
-	00000000f0844cb5294adfa3 = effects/pingrek_glow.png
-	0000000003873088fcc68ccf = effects/pingrek_blast.png
-	00000000c975e4498854c944 = effects/pingrek_blast1.png
-	000000002847bcab30a8019b = effects/ice_castle.png
-	00000000c42085193ff1532b = effects/aurora.png
-	00000000dbfe091764cf7a0a = effects/pingrek_shield.png
+	00000000098b1cca0ddf97bd = effects/ice.png
+	00000000be8a14c54d1cdbb3 = effects/ice_wall.png
+	# HASH_TO_UPDATE_0000000054658d4eb0b561d7 = effects/ice_wall_sleep.png
+	# HASH_TO_UPDATE_00000000a88451fb6a70330f = effects/ice_dust.png
+	# HASH_TO_UPDATE_00000000f11fe5219ba2dd26 = effects/pingrek_heal.png
+	00000000e832918774817cfe = effects/pingrek_heal_1.png
+	000000002fdcf6031a97de18 = effects/pingrek_normalise.png
+	0000000014052d91da6a2d7b = effects/pingrek_summon.png
+	# HASH_TO_UPDATE_000000006b9cc777f90af6d7 = effects/pingrek_magic.png
+	000000008c037cae9a0b1841 = effects/pingrek_magic_1.png
+	000000003cc93a4576387e47 = effects/pingrek_attack.png
+	00000000f0844cb53831f506 = effects/pingrek_glow.png
+	0000000003873088b5e6f17a = effects/pingrek_blast.png
+	00000000c975e449d9449f67 = effects/pingrek_blast1.png
+	000000002847bcab8593ede1 = effects/ice_castle.png
+	00000000c420851937313091 = effects/aurora.png
+	# HASH_TO_UPDATE_00000000dbfe091764cf7a0a = effects/pingrek_shield.png
 	
 	# Piekron effects
-	000000007319983573b20bf0 = effects/piekron_rain.png
-	00000000bd7c8e0091cd5790 = effects/clouds.png
-	00000000c2bb36ad33588b3b = effects/piekron_lightning.png
-	000000007d8185acadb7fab1 = effects/piekron_meditation.png
-	00000000362237b55127ccc9 = effects/piekron_flash.png
+	00000000731998353e2e53b1 = effects/piekron_rain.png
+	00000000bd7c8e0015f6fb43 = effects/clouds.png
+	00000000c2bb36ad389144d2 = effects/piekron_lightning.png
+	000000007d8185ac8f08e23a = effects/piekron_meditation.png
+	00000000362237b5f9f50ab7 = effects/piekron_flash.png
 	
 	# Pyokorider effects
-	0000000047779e88c04ed266 = effects/pyokorider_dash.png
+	# HASH_TO_UPDATE_0000000047779e88c04ed266 = effects/pyokorider_dash.png
 	
 	# Wondabarappa effects
-	00000000b5794c4696991e1d = effects/wondabarappa_support.png
-	000000002c18c95dcd403209 = effects/megapon_sound.png
+	00000000b5794c467e073467 = effects/wondabarappa_support.png
+	000000002c18c95dee3380d6 = effects/megapon_sound.png
 	
 	# Jamsch effects
-	000000008879579f0734f470 = effects/jamsch_sound.png
-	00000000d238508a2924f447 = effects/mushroom.png
-	000000008f0360a5c332e8f2 = effects/poison_cloud.png
-	000000007cb7e37372cd46ba = effects/spores.png
-	000000007e7f396e91330d3b = effects/spores_big.png
-	000000003e4067724d40cca0 = effects/spores_big_1.png
-	00000000650ecb3db2dc7ae1 = effects/jamsch_bass.png
+	000000008879579f33666cad = effects/jamsch_sound.png
+	# HASH_TO_UPDATE_00000000d238508a2924f447 = effects/mushroom.png
+	# HASH_TO_UPDATE_000000008f0360a5c332e8f2 = effects/poison_cloud.png
+	# HASH_TO_UPDATE_000000007cb7e37372cd46ba = effects/spores.png
+	# HASH_TO_UPDATE_000000007e7f396e91330d3b = effects/spores_big.png
+	# HASH_TO_UPDATE_000000003e4067724d40cca0 = effects/spores_big_1.png
+	00000000650ecb3d07050457 = effects/jamsch_bass.png
 	
 	# Destrobo effects
-	000000007ad084b8d41e02d6 = effects/destrobo_swirl.png
-	00000000ed18a4667f0afb69 = effects/destrobo_rock.png
-	0000000037ed666666dad857 = effects/giant_rock.png
-	00000000cdcf2d76ec9badb1 = effects/giant_rock.png
+	000000007ad084b814803cd7 = effects/destrobo_swirl.png
+	00000000ed18a466b42de846 = effects/destrobo_rock.png
+	0000000037ed66666c435447 = effects/giant_rock.png
+	00000000cdcf2d7676b34a13 = effects/giant_rock.png
 	
 	# Bowmunk effects
-	000000000b519db29e164ae2 = effects/bowmunk_grass_move.png
-	00000000125be8bb94a16190 = effects/bowmunk_grass.png
-	00000000465b7b1f55c22f46 = effects/bowmunk_grass_2.png
-	00000000b60b49fa0bf2474b = effects/bowmunk_dirt.png
-	000000007b79913bb9932498 = effects/bowmunk_boulder.png
-	000000001e656c18a8ea630f = effects/bowmunk_dust.png
+	000000000b519db2c32bdd1b = effects/bowmunk_grass_move.png
+	00000000125be8bb72813e1d = effects/bowmunk_grass.png
+	00000000465b7b1f074d1bb1 = effects/bowmunk_grass_2.png
+	00000000b60b49fa0da8c1d7 = effects/bowmunk_dirt.png
+	000000007b79913b4df8ecfe = effects/bowmunk_boulder.png
+	000000001e656c18bab3046f = effects/bowmunk_dust.png
 	
 	# Grenburr effects
-	000000009ee11ff10d7aac75 = effects/grenburr_shockwave.png
-	0000000009ea56a58769db09 = effects/grenburr_charge.png
+	000000009ee11ff127c5b7ea = effects/grenburr_shockwave.png
+	0000000009ea56a570a04fcc = effects/grenburr_charge.png
 	
 	# Kibadda effects
-	00000000f035426b74b44a25 = effects/kibadda_dash.png
-	000000005d75e18117666370 = effects/kibadda_hit.png
+	00000000f035426b294acb18 = effects/kibadda_dash.png
+	000000005d75e181d1dd72be = effects/kibadda_hit.png
 
 #==============Hideout==============#
 
-	00000000b5cf8fa513cbf4b7 = hideout/tents.png
-	0000000017524bab713ca33d = hideout/cavewall.png
-	0000000005940e687c33478f = hideout/bgate.png
-	000000007690a2036108ea00 = hideout/glow.png
-	00000000f0fe84fcfc705b96 = hideout/obelisk.png
-	00000000ebbfa5a9dbeabeb7 = hideout/teamtotem.png
-	00000000dc666c3fb6b58302 = hideout/watchtower.png
-	000000009d65d975e195cd43 = hideout/blacksmithsign.png
-	000000000422723fdd751141 = hideout/armoury.png
-	0000000054d5aa64c9d10514 = hideout/herogate.png
-	00000000113c682a51e60edf = hideout/teamflag.png
-	0000000053b7b83700000000 = hideout/altarmisc.png
-	000000001a4c37e7577555cf = hideout/backgroundstuff.png
-	00000000482a28695782a845 = hideout/misc.png
-	00000000ae7565564c8b9343 = hideout/forge.png
-	00000000ff88b3903bb970ac = hideout/forgebanneraxe.png
-	000000005bb49db9b302b69c = hideout/sukopon.png
+	00000000b5cf8fa5e97e3f70 = hideout/tents.png
+	0000000017524bab9948b14b = hideout/cavewall.png
+	0000000005940e68b49a4672 = hideout/bgate.png
+	000000007690a20306e499c9 = hideout/glow.png
+	00000000f0fe84fc40ea097d = hideout/obelisk.png
+	00000000ebbfa5a9984833c7 = hideout/teamtotem.png
+	00000000dc666c3f61ceeb43 = hideout/watchtower.png
+	000000009d65d97549fa766e = hideout/blacksmithsign.png
+	000000000422723f21e88a7b = hideout/armoury.png
+	0000000054d5aa64525884d8 = hideout/herogate.png
+	00000000113c682ad2226d8a = hideout/teamflag.png
+	# HASH_TO_UPDATE_0000000053b7b83700000000 = hideout/altarmisc.png
+	000000001a4c37e7f617c41d = hideout/backgroundstuff.png
+	00000000482a28691a981933 = hideout/misc.png
+	00000000ae756556a61ca941 = hideout/forge.png
+	# HASH_TO_UPDATE_00000000ff88b3903bb970ac = hideout/forgebanneraxe.png
+	000000005bb49db90a9935e8 = hideout/sukopon.png
 	
 	# Saved Patapons
-	00000000f195e6058046d5a1 = hideout/altarglow.png
-	0000000051f5abb73d8d188d = hideout/plate.png
-	00000000ca322c1eabeaf410 = hideout/meat.png
-	00000000a652f0603807b618 = hideout/dancerhat.png
-	0000000026597b734b460ac5 = hideout/dancerhat1.png
-	000000001569206f01f6e034 = hideout/spear.png
-	0000000076ec01198880192d = hideout/pot.png
-	000000007cd4cf87b9634401 = hideout/staff.png
-	0000000061b6edbe855a2547 = hideout/dancer.png
-	00000000d164168eb26ced16 = hideout/dancer1.png
+	00000000f195e605b40be5d5 = hideout/altarglow.png
+	0000000051f5abb77947268e = hideout/plate.png
+	00000000ca322c1eaeaf0c27 = hideout/meat.png
+	00000000a652f0609d75574c = hideout/dancerhat.png
+	0000000026597b73fe6760b2 = hideout/dancerhat1.png
+	000000001569206f2081deb6 = hideout/spear.png
+	0000000076ec0119b85b018b = hideout/pot.png
+	000000007cd4cf87ff27a232 = hideout/staff.png
+	0000000061b6edbe74182644 = hideout/dancer.png
+	00000000d164168eeffccd65 = hideout/dancer1.png
 	
 		# Barracks
-		000000001dbfa5d6df858055 = hideout/barracks/barrackstand.png
-		0000000000a2d663fd78f026 = hideout/barracks/barracks_top_left.png
-		000000006900b12372ca0e6d = hideout/barracks/barracks_top.png
-		0000000078e9273d16a7daba = hideout/barracks/barracks_top1.png
-		00000000c1fe50ad7d0987b0 = hideout/barracks/barracks_top_right.png
-		00000000a878ecdb70c7bc64 = hideout/barracks/barracks_bottom_left.png
-		00000000d526b4e28036f46c = hideout/barracks/barracks_bottom.png
-		000000002295ec9f1a1bd764 = hideout/barracks/barracks_bottom1.png
-		0000000091302d677dfa808f = hideout/barracks/barracks_bottom_right.png
+		000000001dbfa5d660bbfb6f = hideout/barracks/barrackstand.png
+		0000000000a2d6632d9de521 = hideout/barracks/barracks_top_left.png
+		000000006900b1239fd4076e = hideout/barracks/barracks_top.png
+		0000000078e9273d6751d39e = hideout/barracks/barracks_top1.png
+		00000000c1fe50ad7eb59447 = hideout/barracks/barracks_top_right.png
+		00000000a878ecdb85a3fa5a = hideout/barracks/barracks_bottom_left.png
+		00000000d526b4e20aca94da = hideout/barracks/barracks_bottom.png
+		000000002295ec9f6cd42d8f = hideout/barracks/barracks_bottom1.png
+		0000000091302d673add438e = hideout/barracks/barracks_bottom_right.png
 
 #==============Patapons==============#
 
-	0000000096e59bcf8d9f2514 = patapons/princess.png
-	000000004a130c0e77aef365 = patapons/meden.png
-	0000000006d3dd34b3f71093 = patapons/hoshipon.png
-	00000000f4e4a07322671a86 = patapons/hoshipon.png
-	000000006d72f5f000b35536 = patapons/pataponsprite.png
+	0000000096e59bcfeac97c08 = patapons/princess.png
+	000000004a130c0e3ecb1748 = patapons/meden.png
+	0000000006d3dd34fc135abc = patapons/hoshipon.png
+	000000006d72f5f07b85713f = patapons/pataponsprite.png
 
 #==============Playable==============#
 
 	# Hatapon
-		000000002645206146ddf58e = patapons/playable/hatapon.png
+		0000000026452061964f1d46 = patapons/playable/hatapon.png
 
 	# Shield
-		00000000d7ebb2c2c38429ca = patapons/playable/shield/tatepon.png
+		00000000d7ebb2c225d3e6e8 = patapons/playable/shield/tatepon.png
 		
 		# Destrobo and Bowmunk
-		00000000ad30e9f308013fcb = hideout/units/robopon.png
-		00000000778b4e8d041c08df = patapons/playable/shield/bowmunk_max.png
+		00000000ad30e9f398f1ed78 = hideout/units/robopon.png
+		# HASH_TO_UPDATE_00000000778b4e8d041c08df = patapons/playable/shield/bowmunk_max.png
 		
 		# Guardira
-		00000000825a1e12487bb921 = hideout/units/guardira.png
-		000000009fdf420bd5d38680 = patapons/playable/shield/guardira_max.png
+		00000000825a1e12e0655b15 = hideout/units/guardira.png
+		# HASH_TO_UPDATE_000000009fdf420bd5d38680 = patapons/playable/shield/guardira_max.png
 		
 		# Grenburr
-		000000003df01cffcdf89914 = hideout/units/grenburr.png
+		000000003df01cff1309d56f = hideout/units/grenburr.png
 		
 		# Tondenga and Myamsar
-		0000000070553e8a12edbf55 = hideout/units/dekapon.png
-		00000000a0ad4081a5fcfdbd = patapons/playable/shield/dekapon.png
-		000000001675e7ea9471fea9 = patapons/playable/shield/tondenga_1.png
-		00000000d5882d26d19bf716 = patapons/playable/shield/tondenga_max.png
+		0000000070553e8a6035605b = hideout/units/dekapon.png
+		00000000a0ad4081b29f7da4 = patapons/playable/shield/dekapon.png
+		000000001675e7ea76a7e26b = patapons/playable/shield/tondenga_1.png
+		00000000d5882d26fd9a6140 = patapons/playable/shield/tondenga_max.png
 		
 		
 		# Grenburr
-		00000000271cb0f5413da718 = patapons\playable\shield/grenburr_max.png
+		00000000271cb0f5413da718 = patapons/playable/shield/grenburr_max.png
 		
 	# Bow
 		
-		000000005e9ae6104a94cfbc = patapons/playable/bow/alosson.png
-		000000006f68046e69aef54c = patapons/playable/bow/alosson_max.png
-		00000000e202f96800377c6e = patapons/playable/bow/yumipon.png
+		000000005e9ae6109e3003e3 = patapons/playable/bow/alosson.png
+		000000006f68046e33f81f4a = patapons/playable/bow/alosson_max.png
+		00000000e202f9688c055ffd = patapons/playable/bow/yumipon.png
 		# Pingrek and Oohoroc
-		000000003d37d34acc768064 = hideout/units/mahopon.png
-		00000000b2779f86107f40f5 = patapons/playable/bow/pingrek_max.png
-		000000004d58df85234999a6 = patapons/playable/bow/oohoroc_1.png
-		000000002dd6a749ce77251a = patapons/playable/bow/oohoroc_max.png
+		000000003d37d34a52d39ac0 = hideout/units/mahopon.png
+		# HASH_TO_UPDATE_00000000b2779f86107f40f5 = patapons/playable/bow/pingrek_max.png
+		000000004d58df853a5ffd8b = patapons/playable/bow/oohoroc_1.png
+		# HASH_TO_UPDATE_000000002dd6a749ce77251a = patapons/playable/bow/oohoroc_max.png
 		
 		# Wondabarappa and Jamsch
-		0000000052d0129b1316255a = hideout/units/megapon.png
+		0000000052d0129bc9060bea = hideout/units/megapon.png
 		00000000be4ba952c4340ca9 = patapons/playable/bow/megapon.png
-		00000000be4ba9529dfc6c8f = patapons/playable/bow/megapon.png
-		00000000e142409834e398f4 = patapons/playable/bow/jamsch_max.png
+		00000000be4ba952d93c64d2 = patapons/playable/bow/megapon.png
+		00000000e142409877e41849 = patapons/playable/bow/jamsch_max.png
 		00000000828334727d5010ef = patapons/playable/bow/wondabarappa_max.png
 		
 		# Cannogabang
-		00000000935ec12a22eb3d33 = hideout/units/cannogabang.png
-		00000000fcc24e6fade82481 = patapons/playable/bow/cannogabang_max.png
+		00000000935ec12a83a22020 = hideout/units/cannogabang.png
+		00000000fcc24e6f3be99f56 = patapons/playable/bow/cannogabang_max.png
 	
 		
 	# Spear
 		# Yarida
-		00000000814a6227744ddbbb = hideout/units/yaripon.png
-		00000000770b705666b5465f = patapons/playable/spear/yaripon.png
+		00000000814a6227cebfcc97 = hideout/units/yaripon.png
+		00000000770b70566e15ca3e = patapons/playable/spear/yaripon.png
 		
 		# Piekron
-		00000000a9a2dafd87f4fd4f = patapons/playable/spear/piekron_max.png
+		# HASH_TO_UPDATE_00000000a9a2dafd87f4fd4f = patapons/playable/spear/piekron_max.png
 		
 		# Kibadda and Pyokorider
-		00000000da4e0ba62a2b0787 = hideout/units/kibapon.png
-		00000000e1ac20802a9fefa7 = patapons/playable/spear/kibapon.png
+		00000000da4e0ba6902cd5bd = hideout/units/kibapon.png
+		00000000e1ac20809ab6c503 = patapons/playable/spear/kibapon.png
 		
 		# Wooyari
-		00000000dfb038e90eca8184 = patapons/playable/spear/wooyari_1.png
-		000000008ff487c5b8d77f79 = patapons/playable/spear/wooyari_max.png
+		00000000dfb038e975373994 = patapons/playable/spear/wooyari_1.png
+		# HASH_TO_UPDATE_000000008ff487c5b8d77f79 = patapons/playable/spear/wooyari_max.png
 		
 		# Cannassault
-		000000002abed60f99de7f63 = hideout/units/cannassault.png
+		000000002abed60f97a2700d = hideout/units/cannassault.png
 		
 		# Charibasa
-		0000000001494742eff128e3 = hideout/units/charibasa.png
-		0000000071c9d9b933517b40 = patapons/playable/spear/charibasa.png
-		0000000023eaf06b90ed86a6 = patapons/playable/spear/charibasa_max.png
+		00000000014947424d228190 = hideout/units/charibasa.png
+		0000000071c9d9b96d9b864b = patapons/playable/spear/charibasa.png
+		# HASH_TO_UPDATE_0000000023eaf06b90ed86a6 = patapons/playable/spear/charibasa_max.png
 		
 #==============Hero==============#
 	
-	0000000095b4f94d3a141ba9 = hero/hero_scarf.png
-	000000001dace92c5385bef6 = hero/hero_hand.png
-	0000000028470fceedfea1eb = hero/hero_body.png
-	00000000e384807b3f750ad9 = hero/horse_body.png
+	0000000095b4f94d4a383480 = hero/hero_scarf.png
+	000000001dace92c2f1c98f0 = hero/hero_hand.png
+	0000000028470fce292990e4 = hero/hero_body.png
+	00000000e384807b4805de67 = hero/horse_body.png
 
 		# Hero masks
 			# Shield
 				# Taterazay
-				000000005f057cff4c5c5f5f = hero/mask/taterazay_mask.png
+				000000005f057cff82da7959 = hero/mask/taterazay_mask.png
 				
 				# Tondega 
-				00000000ea87e14d4be95390 = hero/mask/tondenga_mask.png
-				0000000037e945f46e32d0c6 = hero/mask/tondenga_mask_2.png
-				0000000059e2853e3b5dd5f0 = hero/mask/tondenga_mask_max.png
+				00000000ea87e14dd122ddaa = hero/mask/tondenga_mask.png
+				# HASH_TO_UPDATE_0000000037e945f46e32d0c6 = hero/mask/tondenga_mask_2.png
+				0000000059e2853ed122ddaa = hero/mask/tondenga_mask_max.png
 
 				# Myamsar
-				0000000046ef5c221331e8a0 = hero/mask/myamsar_mask.png
-				000000001d6a212ebae667e2 = hero/mask/myamsar_mask_2.png
+				0000000046ef5c22d122ddaa = hero/mask/myamsar_mask.png
+				# HASH_TO_UPDATE_000000001d6a212ebae667e2 = hero/mask/myamsar_mask_2.png
 
 				# Grenburr
-				00000000bd8b1a60a801ba74 = hero/mask/grenburr_mask.png
-				00000000fbdb76cc8f002199 = hero/mask/grenburr_mask_2.png
+				00000000bd8b1a60d122ddaa = hero/mask/grenburr_mask.png
+				# HASH_TO_UPDATE_00000000fbdb76cc8f002199 = hero/mask/grenburr_mask_2.png
 
 				# Guardira
-				0000000003eb01e693263817 = hero/mask/guardira_mask.png
-				0000000026d5438b6bc474a6 = hero/mask/guardira_mask_2.png
+				0000000003eb01e6277e5f55 = hero/mask/guardira_mask.png
+				# HASH_TO_UPDATE_0000000026d5438b6bc474a6 = hero/mask/guardira_mask_2.png
 				
 				# Destrobo
-				000000006f185c50eda02818 = hero/mask/destrobo_mask.png
+				000000006f185c5009531a6f = hero/mask/destrobo_mask.png
 			
 				# Bowmunk
-				00000000b431a7b275beecc8 = hero/mask/bowmunk_mask.png
-				000000006c65525ccb66478e = hero/mask/bowmunk_mask_2.png
-				000000005778d32a918d782d = hero/mask/bowmunk_mask_max.png
+				00000000b431a7b2d122ddaa = hero/mask/bowmunk_mask.png
+				# HASH_TO_UPDATE_000000006c65525ccb66478e = hero/mask/bowmunk_mask_2.png
+				000000005778d32adc0b6a25 = hero/mask/bowmunk_mask_max.png
 		
 			# Bow
 				# Yumiyacha
-				0000000098e8ef4912865450 = hero/mask/yumiyacha_mask.png
+				0000000098e8ef493218954c = hero/mask/yumiyacha_mask.png
 				
 				# Jamsch
-				00000000263afd4e957b2019 = hero/mask/jamsch_mask.png
-				00000000d1894a652e2cef91 = hero/mask/jamsch_mask_2.png
-				000000003d4aaca1aae9f75a = hero/mask/jamsch_mask_max.png
+				00000000263afd4ed122ddaa = hero/mask/jamsch_mask.png
+				00000000d1894a65d122ddaa = hero/mask/jamsch_mask_2.png
+				000000003d4aaca188bf6c6b = hero/mask/jamsch_mask_max.png
 				
 				# Wondabarappa
-				000000001e147a0c8d4bdec1 = hero/mask/wondabarappa_mask.png
-				00000000ae23dfbd7fd361c9 = hero/mask/wondabarappa_mask_2.png
-				00000000d847ea7994edbc87 = hero/mask/wondabarappa_mask_max.png
+				000000001e147a0cd122ddaa = hero/mask/wondabarappa_mask.png
+				00000000ae23dfbdd122ddaa = hero/mask/wondabarappa_mask_2.png
+				00000000d847ea797ac58fd6 = hero/mask/wondabarappa_mask_max.png
 				
 				# Alosson
-				00000000316da103cdc1df55 = hero/mask/alosson_mask.png
-				000000000bbbabd1974a0093 = hero/mask/alosson_mask_2.png
-				000000001a01ef80a2b9813f = hero/mask/alosson_mask_max.png
+				00000000316da103d122ddaa = hero/mask/alosson_mask.png
+				# HASH_TO_UPDATE_000000000bbbabd1974a0093 = hero/mask/alosson_mask_2.png
+				000000001a01ef80db8227e5 = hero/mask/alosson_mask_max.png
 
 				# Cannogabang
-				00000000bae739d1e27394f3 = hero/mask/cannogabang_mask.png
-				000000002df6826d4995ea37 = hero/mask/cannogabang_mask_2.png
-				000000001cd1315705244228 = hero/mask/cannogabang_mask_max.png
+				00000000bae739d1d122ddaa = hero/mask/cannogabang_mask.png
+				# HASH_TO_UPDATE_000000002df6826d4995ea37 = hero/mask/cannogabang_mask_2.png
+				000000001cd1315793fc7703 = hero/mask/cannogabang_mask_max.png
 				
 				# Pingrek
-				00000000cebf67406c4f5546 = hero/mask/pingrek_mask.png
-				000000000262574cfd69b1af = hero/mask/pingrek_mask_2.png
-				0000000016be5c51882122f5 = hero/mask/pingrek_mask_max.png
+				00000000cebf6740d122ddaa = hero/mask/pingrek_mask.png
+				000000000262574cd122ddaa = hero/mask/pingrek_mask_2.png
+				0000000016be5c51d122ddaa = hero/mask/pingrek_mask_max.png
 				
 				# Oohoroc
-				0000000037b14e98831c78db = hero/mask/oohoroc_mask.png
-				000000009bc271d391401ef9 = hero/mask/oohoroc_mask_2.png
-				00000000c695e1a03aeebc49 = hero/mask/oohoroc_mask_max.png
+				0000000037b14e98d122ddaa = hero/mask/oohoroc_mask.png
+				000000009bc271d3d122ddaa = hero/mask/oohoroc_mask_2.png
+				00000000c695e1a0ff63468a = hero/mask/oohoroc_mask_max.png
 		
 			# Spear
 				# Yarida
-				0000000079956253e3ebf4a1 = hero/mask/yarida_mask.png
+				000000007995625382da7959 = hero/mask/yarida_mask.png
 				
 				# Kibadda
-				000000004cb05047ded5694e = hero/mask/kibadda_mask.png
+				000000004cb05047c2df7712 = hero/mask/kibadda_mask.png
 				
 				# Cannassault
-				0000000016c64e4d165cb133 = hero/mask/cannassault_mask.png
-				00000000e87827874aa74f3c = hero/mask/cannassault_mask_2.png
-				0000000004d51497915f4966 = hero/mask/cannassault_mask_max.png
+				0000000016c64e4d9f4716b5 = hero/mask/cannassault_mask.png
+				00000000e8782787acc8dc5f = hero/mask/cannassault_mask_2.png
+				0000000004d514971826949a = hero/mask/cannassault_mask_max.png
 
 				# Charibasa
-				00000000d933a452ce22d930 = hero/mask/charibasa_mask.png
-				0000000053f7a1d663a124ec = hero/mask/charibasa_mask_2.png
-				00000000dbc298ceffc85c1d = hero/mask/charibasa_mask_max.png
+				00000000d933a4527d1986bc = hero/mask/charibasa_mask.png
+				# HASH_TO_UPDATE_0000000053f7a1d663a124ec = hero/mask/charibasa_mask_2.png
+				00000000dbc298cefbea149f = hero/mask/charibasa_mask_max.png
 
 				# Piekron
-				000000002a99867249f963a1 = hero/mask/piekron_mask.png
-				00000000d2a4d6764e19e533 = hero/mask/piekron_mask_2.png
-				00000000b9fc9501e11c22e9 = hero/mask/piekron_mask_max.png
+				000000002a998672a66325d0 = hero/mask/piekron_mask.png
+				00000000d2a4d6769d1ecd3c = hero/mask/piekron_mask_2.png
+				00000000b9fc95014d2156c2 = hero/mask/piekron_mask_max.png
 
 				# Pyokorider
-				00000000f2a9b4fc48afcd21 = hero/mask/pyokorider_mask.png
-				000000002e262e002e469c36 = hero/mask/pyokorider_mask_2.png
-				0000000089872e3d414b2a75 = hero/mask/pyokorider_mask_max.png
+				00000000f2a9b4fcdae2bcd6 = hero/mask/pyokorider_mask.png
+				000000002e262e00013c90f5 = hero/mask/pyokorider_mask_2.png
+				0000000089872e3d2c22df55 = hero/mask/pyokorider_mask_max.png
 
 				# Wooyari
-				00000000d33e14e489d71af3 = hero/mask/wooyari_mask.png
-				00000000b36c7945b1f7a05b = hero/mask/wooyari_mask_2.png
-				00000000b46813c8d09c0b27 = hero/mask/wooyari_mask_max.png
+				00000000d33e14e4d263fffc = hero/mask/wooyari_mask.png
+				00000000b36c79450c256afc = hero/mask/wooyari_mask_2.png
+				00000000b46813c8b0a934f0 = hero/mask/wooyari_mask_max.png
 	
 		# Hair
-		00000000c9d471b6f6078709 = hero/hair/hair.png
-		000000009cbac9d656277a94 = hero/hair/hair_1.png
-		00000000b227a973ed23e852 = hero/hair/hair_2.png
-		00000000c2b8cfb744abc531 = hero/hair/hair_3.png
+		00000000c9d471b63200db2a = hero/hair/hair.png
+		000000009cbac9d66c4f7f86 = hero/hair/hair_1.png
+		00000000b227a97338b2ee98 = hero/hair/hair_2.png
+		# HASH_TO_UPDATE_00000000c2b8cfb744abc531 = hero/hair/hair_3.png
 		
 #============== Dark Hero==============#
 
 
-	000000001276b229df581e62 = hero/hero_body.png
+	000000001276b229cf872768 = hero/hero_body.png
 
 		# Dark Hero masks
 
 			# Naughtyfins
-			00000000d705fae9754a36e0 = darkhero/mask/naughtyfins_mask.png
+			00000000d705fae9f640766c = darkhero/mask/naughtyfins_mask.png
 
 			# Ragewolf
-			000000006666ac76ed26ba80 = darkhero/mask/ragewolf_mask.png
+			000000006666ac76d88bc99a = darkhero/mask/ragewolf_mask.png
 
 			# Sonarchy
-			0000000087b2d057473badd8 = darkhero/mask/sonarchy_mask.png
+			0000000087b2d05749e2bdd3 = darkhero/mask/sonarchy_mask.png
 
 			# Ravenous
-			000000009ea9f4c2cb59feed = darkhero/mask/ravenous_mask.png
+			000000009ea9f4c2194d9c40 = darkhero/mask/ravenous_mask.png
 
 			# Buzzcrave
-			000000009edcb1cb9e216c41 = darkhero/mask/buzzcrave_mask.png
+			000000009edcb1cb5906074c = darkhero/mask/buzzcrave_mask.png
 
 			# Slogturtle
-			00000000a27e81ca07ba4374 = darkhero/mask/slogturtle_mask.png
+			00000000a27e81ca33532753 = darkhero/mask/slogturtle_mask.png
 
 			# Miss Covet-Hiss
-			00000000461eb9d63f9b8fb6 = darkhero/mask/miss_covet_hiss.png
+			00000000461eb9d6a87e162e = darkhero/mask/miss_covet_hiss.png
 
 		# Dark Hero Equipment
 
 			# Warhorse Ponteo
-			00000000727cf32603fc2c1b = darkhero/equipment/warhorse_ponteo.png
+			00000000727cf3269b6bf34d = darkhero/equipment/warhorse_ponteo.png
 
 			# Warhorse Ponteo body
-			00000000ddbd8c8a8858d1a7 = darkhero/equipment/warhorse_ponteo_body.png
+			00000000ddbd8c8a661fc280 = darkhero/equipment/warhorse_ponteo_body.png
 	
 #==============Items==============#
 
-	00000000d9515dc000000000 = items/bone.png
-	00000000dcd3d44000000000 = items/branch.png
-	0000000023a67dcb00000000 = items/branch_cherry.png
-	00000000d482d38f00000000 = items/rock.png
-	00000000c2b8dda400000000 = items/stone.png
-	000000007d24316a00000000 = items/green_potion.png
-	0000000095d8e71d00000000 = items/kaching.png
-	000000004a83977332ed0ddf = items/key.png
+	00000000d9515dc0a9b42acc = items/bone.png
+	00000000dcd3d44052e9068b = items/branch.png
+	0000000023a67dcba87ff5ff = items/branch_cherry.png
+	00000000d482d38f3460f9f6 = items/rock.png
+	00000000c2b8dda469ef2911 = items/stone.png
+	000000007d24316a00b997a1 = items/green_potion.png
+	# HASH_TO_UPDATE_0000000095d8e71d00000000 = items/kaching.png
+	# HASH_TO_UPDATE_000000004a83977332ed0ddf = items/key.png
 	
 	# Chests
 		# Wood
-		0000000079cf75de5ae4a4b0 = items/chest_wood.png
+		0000000079cf75de255f1b49 = items/chest_wood.png
 			# Cellshaded
-			0000000019122051bead94af = items/chest_wood_3d_cell.png
+			000000001912205187b374b1 = items/chest_wood_3d_cell.png
 
 		# Iron
-		00000000067bd2fe9f41971e = items/chest_iron.png
+		00000000067bd2fe1ae002fd = items/chest_iron.png
 			# Cellshaded
-			00000000c044a4f354deb29d = items/chest_iron_3d_cell.png
+			00000000c044a4f35b72c1da = items/chest_iron_3d_cell.png
 
 		# Gold
-		000000002c91a7decb2a1778 = items/chest_gold.png
+		000000002c91a7dea612fced = items/chest_gold.png
 			# Cellshaded
-			00000000de5c91ea30a4e548 = items/chest_gold_3d_cell.png
+			00000000de5c91ea6afda447 = items/chest_gold_3d_cell.png
 		
 		# Jewel
-		000000002c89000d95e0a3de = items/chest_jewel.png
+		000000002c89000deb512bef = items/chest_jewel.png
 			# Cellshaded
-			0000000046f7ee72a515990b = items/purple_jewel_3d_cell.png
-			= items/blue_jewel_3d_cell.png
+			# HASH_TO_UPDATE_0000000046f7ee72a515990b = items/purple_jewel_3d_cell.png = items/blue_jewel_3d_cell.png
 
 #==============Enemies==============#
 
 	# Giants
-	0000000052ebb51054efa65f = enemies/giant.png
-	0000000055d199d807d168a3 = enemies/big_giant.png
+	0000000052ebb510ba715680 = enemies/giant.png
+	0000000055d199d8446879e2 = enemies/big_giant.png
 	
 	# Bonedeth
-	0000000023fe707f00f85549 = enemies/bonedeth_1.png
-	000000001a634c1f283bc27d = enemies/bonedeth_2.png
-	0000000072d569ebc8ef5789 = enemies/bonedeth_3.png
+	0000000023fe707fb8880b39 = enemies/bonedeth_1.png
+	000000001a634c1f4bb71653 = enemies/bonedeth_2.png
+	0000000072d569eb496b2d59 = enemies/bonedeth_3.png
 	
 	# Akumapon
-	00000000a108a2c707d89556 = enemies/akumapons_sprite.png
+	00000000a108a2c7e20844cf = enemies/akumapons_sprite.png
 	
 	# Mochichi
-	000000006ae2fb2062dc8a2c = enemies/mochichi.png
-	0000000002befdd75fa2c6c2 = enemies/mochichi_gold.png
+	000000006ae2fb2081bde2a6 = enemies/mochichi.png
+	# HASH_TO_UPDATE_0000000002befdd75fa2c6c2 = enemies/mochichi_gold.png
 	
 	# Stone Golem
-	0000000084b4f711699a40c5 = enemies/golem.png
-	000000001d160a2e306db6cd = enemies/golem_arm.png
+	0000000084b4f7116a6109a7 = enemies/golem.png
+	000000001d160a2e0ac35856 = enemies/golem_arm.png
 	
 		#==============Bosses==============#
 		
 		# Dodonga, Majidonga & Kachidonga
-		00000000acc729e9dc2d2399 = enemies/bosses/dodonga.png
+		# HASH_TO_UPDATE_00000000acc729e9dc2d2399 = enemies/bosses/dodonga.png
 		
 		# Gaeen & Dogaeen
-		00000000812628d347e1f470 = enemies/bosses/gaeen.png
-		0000000034e5aabd4d62998d = enemies/bosses/dogaeen.png
+		# HASH_TO_UPDATE_00000000812628d347e1f470 = enemies/bosses/gaeen.png
+		# HASH_TO_UPDATE_0000000034e5aabd4d62998d = enemies/bosses/dogaeen.png
 		
 		# Manboth & Manboroth
-		000000007e32f1888ec557db = enemies/bosses/manboth.png
+		000000007e32f188ec1bb242 = enemies/bosses/manboth.png
 		
 		# Shookle & Shooshookle
-		00000000961eedbca465f2d3 = enemies/bosses/shookle.png
+		# HASH_TO_UPDATE_00000000961eedbca465f2d3 = enemies/bosses/shookle.png
 
 
 #==============Equipment==============#
@@ -798,321 +798,321 @@ hash = quick
 	
 	# Arms
 		# Basic arm
-		00000000ef296de0897be46e = eq/arm/arm.png
+		00000000ef296de0917337cf = eq/arm/arm.png
 		
 		# Natura's Touch
-		000000006d6c9f4b11307645 = eq/arm/natura.png
-		000000009c944098a834b808 = eq/arm/hero/natura.png
+		000000006d6c9f4b0d28af27 = eq/arm/natura.png
+		000000009c944098b682fedc = eq/arm/hero/natura.png
 	
 		# Chosan arm
-		000000002a58e24843d6ea32 = eq/arm/chosan.png
-		000000009cd11789666ad504 = eq/arm/hero/chosan.png
+		000000002a58e24810b9a53a = eq/arm/chosan.png
+		000000009cd11789b5b3b3a9 = eq/arm/hero/chosan.png
 	
 		# Pingar zingar
-		000000007e3dbf9044df42f2 = eq/arm/pingar.png
-		000000006b889562e47b349d = eq/arm/hero/pingar.png
+		000000007e3dbf90db23a231 = eq/arm/pingar.png
+		000000006b889562fbd338bc = eq/arm/hero/pingar.png
 		
 		# Super Megadogu arm
-		00000000d5f3744aa081b10c = eq/arm/super_megadogu.png
+		# HASH_TO_UPDATE_00000000d5f3744aa081b10c = eq/arm/super_megadogu.png
 
 		# Sleep arm
-		00000000ca2c5acdb7c1d034 = eq/arm/sleep_arm.png
+		# HASH_TO_UPDATE_00000000ca2c5acdb7c1d034 = eq/arm/sleep_arm.png
 														
 	
 	# Axes
 		# Stagger axe
-		00000000602502996fc66a87 = eq/axe/hero/stagger_axe_max.png
+		000000006025029950b2d750 = eq/axe/hero/stagger_axe_max.png
 		
 		# Susurapon
-		000000007d8cabe791918428 = eq/axe/hero/susurapon.png
+		000000007d8cabe7437377a8 = eq/axe/hero/susurapon.png
 	
 	# Blades
 		# Blade
-		000000006cef622dfadd67f7 = eq/blade/blade.png
-		0000000084eb0dd1255dabdc = eq/blade/hero/blade.png
+		000000006cef622d5d35cea4 = eq/blade/blade.png
+		0000000084eb0dd1c3f9528e = eq/blade/hero/blade.png
 
 		# Lightning blade
-		00000000f65367d02b430889 = eq/blade/hero/lightning_blade.png
+		00000000f65367d001c25f8c = eq/blade/hero/lightning_blade.png
 	
 	# Bows
 		# Basic bow
-		00000000a115861bb73cf4b9 = eq/bow/bow.png
+		00000000a115861bf335fc18 = eq/bow/bow.png
 
 		# Bow of Apollopon 
-		0000000017f9da1f1faa34ad = eq/bow/bow_of_apollopon.png
+		0000000017f9da1f5fa8214a = eq/bow/bow_of_apollopon.png
 
 		# Rajipon bow
-		0000000021f2e2f056c3e544 = eq/bow/rajipon_bow.png
+		# HASH_TO_UPDATE_0000000021f2e2f056c3e544 = eq/bow/rajipon_bow.png
 		
 	
 	# Cannons
 		# Basic cannon
-		00000000ecddeab666cdd30f = eq/cannon/cannon.png
+		00000000ecddeab628325173 = eq/cannon/cannon.png
 	
 	# Capes
 		# Basic cape
-		000000005084eff75a1c14a6 = eq/capes/cape.png
+		000000005084eff7db5195e4 = eq/capes/cape.png
 	
 		# Ulysses cape
-		000000006d9ef5e12ebe79b4 = eq/capes/ulysses.png
-		00000000a38b17f40f8b3fbe = eq/capes/hero/ulysses.png
+		000000006d9ef5e155470066 = eq/capes/ulysses.png
+		00000000a38b17f4cb2ae449 = eq/capes/hero/ulysses.png
 		
 		# Vampire cape
-		00000000442f4c820ebfb60a = eq/capes/vamp.png
+		00000000442f4c8291ca16f3 = eq/capes/vamp.png
 
 	# Chariots
 		# Basic chariot
-		00000000b19605dd2676bf19 = eq/chariot/chariot.png
+		00000000b19605dd9e78142e = eq/chariot/chariot.png
 		
 		# The Silencer
-		00000000b6c7a7b61aef35b0 = eq/chariot/hero/silencer.png
+		00000000b6c7a7b65ff720ae = eq/chariot/hero/silencer.png
 
 		# Critical Chariot
-		00000000cbaef180502ccc3c = eq/chariot/critical_chariot.png
+		# HASH_TO_UPDATE_00000000cbaef180502ccc3c = eq/chariot/critical_chariot.png
 	
 	# Crossbows
 		# Teskatori shooter
-		00000000b9ccaa91d6d0860b = eq/crossbow/hero/teskatori.png
+		00000000b9ccaa91458a3e55 = eq/crossbow/hero/teskatori.png
 	
 	# Clubs
 		# Lightning club
-		000000005ad5dcc3ee4a59c6 = eq/club/hero/lightning_club_1.png
-		0000000064047d7f8c2886c7 = eq/club/hero/lightning_club_2.png
+		000000005ad5dcc30ace5f39 = eq/club/hero/lightning_club_1.png
+		0000000064047d7fb8d7e802 = eq/club/hero/lightning_club_2.png
 		
 		# Thor
-		0000000079ec8aa1bfa3108d = eq/club/thor.png
-		00000000822bb43482f8db58 = eq/club/hero/thor.png
+		0000000079ec8aa13c413b50 = eq/club/thor.png
+		00000000822bb4347b3a0cbc = eq/club/hero/thor.png
 
 		# Mjollnir
-		00000000ec91ba47d01bd568 = eq/club/hero/mjollnir.png
-		0000000014753aeea5b4b6d6 = eq/club/mjollnir.png
+		00000000ec91ba4727d33167 = eq/club/hero/mjollnir.png
+		# HASH_TO_UPDATE_0000000014753aeea5b4b6d6 = eq/club/mjollnir.png
 		
 	# Daggers
 		# Basic Dagger
-		00000000143bc22cfb968f32 = eq/dagger/dagger.png
-		000000001b11efc1c9ff66e5 = eq/dagger/hero/dagger.png
+		# HASH_TO_UPDATE_00000000143bc22cfb968f32 = eq/dagger/dagger.png
+		000000001b11efc1c085d934 = eq/dagger/hero/dagger.png
 
 	# Greatshields
 		# Basic greatshield
-		000000004bf5104d3f4c4424 = eq/greatshield/greatshield.png
+		# HASH_TO_UPDATE_000000004bf5104d3f4c4424 = eq/greatshield/greatshield.png
 		
 		# Tokoyomamori
-		00000000799c56b957a61f8c = eq/greatshield/tokoyomamori.png
+		00000000799c56b978f95814 = eq/greatshield/tokoyomamori.png
 	
 	# Greatswords
 		# Basic Greatsword
-		0000000084085a75a3059343 = eq/greatsword/greatsword.png
+		0000000084085a75758f9708 = eq/greatsword/greatsword.png
 		
 		# Caladbong
-		000000007bbd6b61a9abc6d6 = eq/greatsword/caladbong.png
+		# HASH_TO_UPDATE_000000007bbd6b61a9abc6d6 = eq/greatsword/caladbong.png
 		
 		# Critical Greatsword
-		00000000fb5605ca72b0f574 = eq/greatsword/hero/crit_gsword.png
+		00000000fb5605cab4152443 = eq/greatsword/hero/crit_gsword.png
 	
 	# Helms
 		# Basic helm
-		00000000b47bb5df25e84da5 = eq/helm/helm.png
-		000000005500f420063ac3d6 = eq/helm/hero/helm.png
+		00000000b47bb5df6f1ffdfc = eq/helm/helm.png
+		000000005500f420105257e7 = eq/helm/hero/helm.png
 		
 		# Fire helm
-		0000000090c40a4f47e6cd5c = eq/helm/hero/fire_helm_1.png
-		00000000aa1e1d8788eb712a = eq/helm/fire_helm.png
+		0000000090c40a4ff14b3eaa = eq/helm/hero/fire_helm_1.png
+		# HASH_TO_UPDATE_00000000aa1e1d8788eb712a = eq/helm/fire_helm.png
 		
 		# Lightning helm
-		000000003335e78f4db5a879 = eq/helm/hero/lightning_helm_2.png
-		00000000fbcc872a7f03a918 = eq/helm/hero/lightning_helm.png
-		0000000070b3512bb66554e3 = eq/helm/lightning_helm.png
-		000000001c49ad06c71703de = eq/helm/lightning_helm_1.png
+		000000003335e78f56f2119f = eq/helm/hero/lightning_helm_2.png
+		00000000fbcc872acfe8cab4 = eq/helm/hero/lightning_helm.png
+		# HASH_TO_UPDATE_0000000070b3512bb66554e3 = eq/helm/lightning_helm.png
+		# HASH_TO_UPDATE_000000001c49ad06c71703de = eq/helm/lightning_helm_1.png
 
 		# Ice helm
-		000000001528788976e4af2f = eq/helm/ice_helm.png
-		0000000026284041c5ac0d5d = eq/helm/hero/ice_helm.png
+		# HASH_TO_UPDATE_000000001528788976e4af2f = eq/helm/ice_helm.png
+		00000000262840418e61a6e1 = eq/helm/hero/ice_helm.png
 
 		# Bunny head
-		000000000effe4b7075fe2d2 = eq/helm/bunny.png
-		00000000202eda1802d28981 = eq/helm/hero/bunny.png
+		000000000effe4b7b74c5cf8 = eq/helm/bunny.png
+		00000000202eda183a8463bc = eq/helm/hero/bunny.png
 		
 		# Samurai helm
-		00000000b9eaa3d578bbf906 = eq/helm/samurai.png
+		00000000b9eaa3d54edbb647 = eq/helm/samurai.png
 		
 		# Shubaba gale
-		000000009d3a536a16d7c629 = eq/helm/shubaba.png
+		000000009d3a536a31412c28 = eq/helm/shubaba.png
 		
 			#DLC Helms
-			00000000a32a4c5803a88d59 = eq/helm/marina.png
-			000000004a060801af072884 = eq/helm/pirate_helm.png
-			00000000d7408008f6a75df0 = eq/helm/masamune_helm.png
-			0000000083a69a805688de0a = eq/helm/straw_helm.png
-			0000000019d30cfaec19bf32 = eq/helm/candle_helm.png
-			000000007e7a9edf208043b4 = eq/helm/bald_helm.png
-			000000002d02f521755755a8 = eq/helm/clown_helm.png
-			000000008e7265872f88fbc4 = eq/helm/thief_helm.png
+			00000000a32a4c58bc530ec6 = eq/helm/marina.png
+			000000004a0608015bc2a946 = eq/helm/pirate_helm.png
+			00000000d740800855277448 = eq/helm/masamune_helm.png
+			0000000083a69a80a6891bc0 = eq/helm/straw_helm.png
+			0000000019d30cfa1f872592 = eq/helm/candle_helm.png
+			000000007e7a9edf70d61a49 = eq/helm/bald_helm.png
+			000000002d02f521533c152f = eq/helm/clown_helm.png
+			000000008e7265876e398f00 = eq/helm/thief_helm.png
 	
 	# Horns
 		# Basic horn
-		0000000016a2cf2c7da822b3 = eq/horn/horn.png
+		0000000016a2cf2c9c2c3c02 = eq/horn/horn.png
 
 	# Horses
 		# Basic horse
-		000000008ac0d0fbe77eff06 = eq/horse/horse.png
-		00000000f7edc77068b1f9c6 = eq/horse/hero/horse.png
+		000000008ac0d0fb6e697b7c = eq/horse/horse.png
+		00000000f7edc770225ef276 = eq/horse/hero/horse.png
 		
 		# Ponbiscuit
-		000000000818014b833f68c1 = eq/horse/ponbiscuit.png
+		000000000818014befff54db = eq/horse/ponbiscuit.png
 		
 		# Sibericus
-		000000000d019a1b943a2dc7 = eq/horse/hero/sibericus.png
+		000000000d019a1bcfb13c43 = eq/horse/hero/sibericus.png
 	
 	# Howitzers
 		# Basic howitzer
-		00000000035a78b5a92a8248 = eq/howitzer/howitzer.png
+		00000000035a78b5938a12cf = eq/howitzer/howitzer.png
 	
 	# Lances
 		# Basic Lance
-		000000008174256814ff565b = eq/lance/lance.png
-		00000000db803a4661a7962c = eq/lance/hero/lance.png
+		000000008174256862a0dda4 = eq/lance/lance.png
+		00000000db803a46c76a176e = eq/lance/hero/lance.png
 
 		# Stagger Lance
-		0000000056ef452dee26b8b6 = eq/lance/stagger_lance_2.png
+		# HASH_TO_UPDATE_0000000056ef452dee26b8b6 = eq/lance/stagger_lance_2.png
 	
 		# Romulu's Halberd
-		000000003af80092a2208167 = eq/lance/hero/romulus.png
+		000000003af800924f773367 = eq/lance/hero/romulus.png
 		
 		# Battachin
-		0000000029b0dd8e5d0fc480 = eq/lance/hero/battachin.png
+		0000000029b0dd8e014e19b9 = eq/lance/hero/battachin.png
 		
 		# Gugnir
-		00000000210a688f48ef97d5 = eq/lance/gugnir.png
-		0000000018101556525ac4e8 = eq/lance/hero/gugnir.png
+		# HASH_TO_UPDATE_00000000210a688f48ef97d5 = eq/lance/gugnir.png
+		000000001810155691a5b3d4 = eq/lance/hero/gugnir.png
 
 		# Incensar
 		00000000d316bcfbcac6a090 = eq/lance/incensar.png
-		00000000fd67f898b1850c0b = eq/lance/hero/incensar.png
+		00000000fd67f898aea36373 = eq/lance/hero/incensar.png
 
 
 	# Lasers
 		# Basic laser
-		0000000001f60159fcb30ba4 = eq/laser/laser.png
+		# HASH_TO_UPDATE_0000000001f60159fcb30ba4 = eq/laser/laser.png
 		
 	#Longhorns
 		# Basic Longhorn
-		000000004352cd896e68bbd9 = eq/longhorn/longhorn.png
+		# HASH_TO_UPDATE_000000004352cd896e68bbd9 = eq/longhorn/longhorn.png
 
 	# Shields
 		# Basic shield
-		000000004d78536444684f1e = eq/shield/shield.png
-		00000000b90b37ee0d8408fa = eq/shield/hero/shield.png
+		000000004d7853646b82e41a = eq/shield/shield.png
+		00000000b90b37eea5a6fa6f = eq/shield/hero/shield.png
 	
 		# Stinger Shield
-		0000000090c83269f4c35b06 = eq/shield/stinger_shield.png
-		000000006e26be31551829ad = eq/shield/hero/stinger_shield.png
+		# HASH_TO_UPDATE_0000000090c83269f4c35b06 = eq/shield/stinger_shield.png
+		000000006e26be31fa7e9724 = eq/shield/hero/stinger_shield.png
 		
 		# Alldemonium Shield
-		00000000abe712210e664ed3 = eq/shield/alldemonium_shield.png
-		0000000076327b3b0e3d20ac = eq/shield/hero/alldemonium_shield.png
+		00000000abe71221c000a68a = eq/shield/alldemonium_shield.png
+		0000000076327b3b457fe2d4 = eq/shield/hero/alldemonium_shield.png
 		
 		# Sleep Shield
-		00000000d6197359f852e4d2 = eq/shield/hero/sleep_shield.png
+		00000000d6197359a839ce16 = eq/shield/hero/sleep_shield.png
 		
 		# Fire Shield
-		00000000f25ccbd3b627903f = eq/shield/hero/fire_shield.png
+		00000000f25ccbd3f4f337a3 = eq/shield/hero/fire_shield.png
 		
 		# Ice Shield
-		0000000082f9dd0fb9b8709a = eq/shield/ice_shield.png
-		0000000065177cea2fa057ef = eq/shield/hero/ice_shield.png
+		0000000082f9dd0f47eeb940 = eq/shield/ice_shield.png
+		0000000065177ceaf451b72f = eq/shield/hero/ice_shield.png
 		
 	# Shivs
 		# Basic Shiv
-		000000006b27c8887c297d32 = eq/shiv/shiv.png
+		# HASH_TO_UPDATE_000000006b27c8887c297d32 = eq/shiv/shiv.png
 	
 	
 		# Poison shiv
-		0000000042b31a97749f7f49 = eq/shiv/hero/poison_shiv_1.png
+		0000000042b31a97cbc7254f = eq/shiv/hero/poison_shiv_1.png
 	
 	# Shoes
 		# Basic shoes
-		00000000604a5f99c65edcbb = eq/shoe/shoe.png
+		00000000604a5f990431f1ee = eq/shoe/shoe.png
 
 	# Shoulders
 		# Basic shoulders
-		0000000010b05cf2311cceff = eq/shoulders/shoulder.png
+		0000000010b05cf250f00fe4 = eq/shoulders/shoulder.png
 
 		# Frayola's splaulders
-		000000007450edd7e8c7d8ec = eq/shoulders/hero/frayola.png
+		000000007450edd786f66fd9 = eq/shoulders/hero/frayola.png
 
 		# Crono Riggers
-		00000000d2b9a977dae7ad46 = eq/shoulders/crono_riggers.png
-		00000000a8b588150246ca68 = eq/shoulders/hero/crono_riggers.png
+		00000000d2b9a97755a893e8 = eq/shoulders/crono_riggers.png
+		00000000a8b588150987a98b = eq/shoulders/hero/crono_riggers.png
 	
 	# Spears
 		# Basic spear
-		00000000cdb5c53838764b50 = eq/spear/spear.png
-		00000000bd6508fa8ab09069 = eq/spear/hero/spear.png
+		00000000cdb5c5382be13b02 = eq/spear/spear.png
+		00000000bd6508faeee5b4c4 = eq/spear/hero/spear.png
 
 		# Critical spear
-		00000000df551a9681452d32 = eq/spear/critical_spear.png
-		000000007bb8617ce509000e = eq/spear/hero/critical_spear.png
+		# HASH_TO_UPDATE_00000000df551a9681452d32 = eq/spear/critical_spear.png
+		000000007bb8617ca4547287 = eq/spear/hero/critical_spear.png
 
 		# Repel spear
-		00000000f7690afc6669fa27 = eq/spear/repel_spear.png
-		00000000999bb0b77f91df26 = eq/spear/hero/repel_spear.png
-		0000000002c6f77817d27614 = eq/spear/hero/repel_spear_2.png
+		00000000f7690afc90959001 = eq/spear/repel_spear.png
+		00000000999bb0b752bcc7d2 = eq/spear/hero/repel_spear.png
+		0000000002c6f778c3510b5b = eq/spear/hero/repel_spear_2.png
 
 		# Dokaknel Fang
-		00000000d7bc3f318a04d89b = eq/spear/dokaknel_fang.png
-		00000000cd95882dfe78f9f9 = eq/spear/hero/dokaknel_fang.png
+		00000000d7bc3f31ff1c0cd7 = eq/spear/dokaknel_fang.png
+		00000000cd95882dcbaa9ba2 = eq/spear/hero/dokaknel_fang.png
 		
 		# Palkyrias flight
-		00000000ae9c4b07e378aaf2 = eq/spear/palkyrias_flight.png
+		# HASH_TO_UPDATE_00000000ae9c4b07e378aaf2 = eq/spear/palkyrias_flight.png
 	
 	# Swords
 		# Basic sword
-		0000000059dfa137e85735b6 = eq/sword/sword.png
-		000000009608dfcbb26f700c = eq/sword/hero/sword.png
+		0000000059dfa13725b70849 = eq/sword/sword.png
+		000000009608dfcb4c717e98 = eq/sword/hero/sword.png
 
 		# Fire sword
-		00000000237e4b4a3d049e5e = eq/sword/hero/fire_sword.png
+		00000000237e4b4a6c84fad2 = eq/sword/hero/fire_sword.png
 
 		# Ice sword
-		000000004009ef021bcf83d5 = eq/sword/hero/ice_sword.png
-		00000000639c0907cdb13043 = eq/sword/hero/ice_sword_1.png
+		000000004009ef02a2b5907d = eq/sword/hero/ice_sword.png
+		00000000639c090762248dfe = eq/sword/hero/ice_sword_1.png
 
 		# Sleepi sword
-		00000000ab5b95ca93674393 = eq/sword/sleepi_sword.png
+		00000000ab5b95cad2c019eb = eq/sword/sleepi_sword.png
 		
 		# Drigonlay
-		00000000dbbcd6a2343a763c = eq/sword/drigonlay.png
+		# HASH_TO_UPDATE_00000000dbbcd6a2343a763c = eq/sword/drigonlay.png
 		
 		# Castram
-		00000000d63f4959d8f4ed46 = eq/sword/hero/castram.png
+		00000000d63f4959c024953a = eq/sword/hero/castram.png
 
 		# Fendus
-		00000000fb2acf8975680baa = eq/sword/fendus.png
-		0000000039bd2bc2e4b5c572 = eq/sword/hero/fendus.png
+		00000000fb2acf89aa4cd2aa = eq/sword/fendus.png
+		0000000039bd2bc284c1c174 = eq/sword/hero/fendus.png
 		
 	# Staffs
 		# Basic Staff
-		000000004c0b1436acceffbf = eq/staff/basic_staff.png
+		000000004c0b1436d9dfbf54 = eq/staff/basic_staff.png
 		
 		# Firewall Staff
-		00000000e980b848b6683c3e = eq/staff/hero/firewall_staff.png
+		00000000e980b8482d5c4632 = eq/staff/hero/firewall_staff.png
 		
 		# Healing Sceptre
-		0000000086b2a72c66393a2f = eq/staff/hero/healing_sceptre.png
+		0000000086b2a72c6dcf87fa = eq/staff/hero/healing_sceptre.png
 		
 		# Purity Sceptre 
-		0000000083e86d919879c048 = eq/staff/hero/purity_sceptre.png
+		0000000083e86d91895c9559 = eq/staff/hero/purity_sceptre.png
 		
 		# Rahmon
-		00000000e089ad25a0accb57 = eq/staff/rahmon.png
+		# HASH_TO_UPDATE_00000000e089ad25a0accb57 = eq/staff/rahmon.png
 
 	# Warhorses
 		# Basic Warhorse
-		000000004ce8a55a29ba6f62 = eq/warhorse/hero/warhorse.png
+		000000004ce8a55a6dac1708 = eq/warhorse/hero/warhorse.png
 		00000000b4432574d2d38adb = eq/warhorse/warhorse.png
 
 		# Deep Impact
-		00000000410b6e06e5ca5390 = eq/warhorse/hero/deep_impact.png
-		000000005fba51b08aa2be4f = eq/warhorse/deep_impact.png												  
+		00000000410b6e06160720c6 = eq/warhorse/hero/deep_impact.png
+		# HASH_TO_UPDATE_000000005fba51b08aa2be4f = eq/warhorse/deep_impact.png
 
 [hashranges]


### PR DESCRIPTION
xh64 is more efficient than quick and avoids collisions.

In addition, reduceHash has been used to improve textures with incorrect dimensions (items, loading tips, eula, ...)

There are some few textures that still need to update their hash I have added the comment "HASH_TO_UPDATE" in them.